### PR TITLE
Fix heigth typo in GUI components

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Button.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Button.java
@@ -9,8 +9,8 @@ import lombok.Setter;
 public abstract class Button extends Component {
     private boolean hovered = false;
     private boolean clicked = false;
-    public Button(int x, int y, int width, int heigth, Texture texture, Gui container) {
-        super(x, y, width, heigth, texture, container);
+    public Button(int x, int y, int width, int height, Texture texture, Gui container) {
+        super(x, y, width, height, texture, container);
     }
 
     public abstract void onClick(Player player) ;

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Component.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Component.java
@@ -24,7 +24,7 @@ public abstract class Component{
     private int x;
     private int y;
     private final int width;
-    private final int heigth;
+    private final int height;
     private Texture texture;
     private Gui container;
     private GuiModule guiModule;
@@ -35,12 +35,12 @@ public abstract class Component{
     // Indices pour dessiner un quad avec deux triangles
     private int[] indices;
 
-    public Component(int x, int y, int width, int heigth, Texture texture, Gui container){
+    public Component(int x, int y, int width, int height, Texture texture, Gui container){
 
         this.x = x;
         this.y = y;
         this.width = GUI_ZOOM*width;
-        this.heigth = GUI_ZOOM*heigth;
+        this.height = GUI_ZOOM*height;
         this.texture = texture;
         this.container = container;
         this.guiModule = GAME.getGraphicModule().getGuiModule();
@@ -58,7 +58,7 @@ public abstract class Component{
     public boolean isCursorIn(){
         int x = getGuiModule().getCursorX();
         int y = getGuiModule().getCursorY();
-        return x >= this.getX() && x < this.getX() + width && y >= this.getY() && y < this.getY() + heigth;
+        return x >= this.getX() && x < this.getX() + width && y >= this.getY() && y < this.getY() + height;
     }
 
     public void set2DTexture(Texture texture) {
@@ -82,8 +82,8 @@ public abstract class Component{
                 // Positions        // Coordonnées de texture
                 x,  y, 0.0f,   0.0f, 1.0f, texture.getId(),   // Haut gauche
                 x + width,  y, 0.0f,   1.0f, 1.0f, texture.getId(),    // Haut droit
-                x, y + heigth, 0.0f,   0.0f, 0.0f, texture.getId(),     // Bas gauche
-                x + width, y + heigth, 0.0f,   1.0f, 0.0f, texture.getId(),    // Bas droit
+                x, y + height, 0.0f,   0.0f, 0.0f, texture.getId(),     // Bas gauche
+                x + width, y + height, 0.0f,   1.0f, 0.0f, texture.getId(),    // Bas droit
         };
         indices =  new int[]{
                 0, 2, 1,   // Premier triangle

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Image.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Image.java
@@ -3,8 +3,8 @@ package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components;
 import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
 
 public class Image extends Component {
-    public Image(int x, int y, int width, int heigth, Texture texture, Gui container) {
-        super(x, y, width, heigth, texture, container);
+    public Image(int x, int y, int width, int height, Texture texture, Gui container) {
+        super(x, y, width, height, texture, container);
     }
 
     @Override

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Slot.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Slot.java
@@ -92,7 +92,7 @@ public class Slot extends Button {
 
             // Position du sommet
             float vx = (verticesBuffer.get(vertexIndex * 3)+0.5f)*this.getWidth() + this.getX();
-            float vy = (verticesBuffer.get(vertexIndex * 3 + 1))*this.getHeigth()+this.getY();
+            float vy = (verticesBuffer.get(vertexIndex * 3 + 1))*this.getHeight()+this.getY();
             float vz = (verticesBuffer.get(vertexIndex * 3 + 2));
 
             // Coordonnées de texture

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/models/BlockUtil.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/models/BlockUtil.java
@@ -235,7 +235,7 @@ public class BlockUtil {
         float z1 = 0f; // Déplacer pour utiliser le coin avant
 
         float x2 = slot.getWidth() + slot.getX(); // Déplacer pour utiliser le coin arrière-droit
-        float y2 = slot.getY() + slot.getHeigth(); // Déplacer pour utiliser le coin haut
+        float y2 = slot.getY() + slot.getHeight(); // Déplacer pour utiliser le coin haut
         float z2 = 1f; // Déplacer pour utiliser le coin arrière
 
         //Tailles du regroupement de blocks:

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/models/SlabUtils.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/models/SlabUtils.java
@@ -179,11 +179,11 @@ public class SlabUtils {
     public static void rasterBlockItem(Item block, Slot slot, ArrayList<float[]> verticesList, ArrayList<Integer> indicesList) {
         // Coordonnées des coins (corner1 est en bas à gauche, corner2 est en haut à droite)
         float x1 = slot.getX(); // Déplacer pour utiliser le coin avant-gauche
-        float y1 = slot.getY() + (float) slot.getHeigth() /2; // Déplacer pour utiliser le coin bas
+        float y1 = slot.getY() + (float) slot.getHeight() /2; // Déplacer pour utiliser le coin bas
         float z1 = 0f; // Déplacer pour utiliser le coin avant
 
         float x2 = slot.getWidth() + slot.getX(); // Déplacer pour utiliser le coin arrière-droit
-        float y2 = slot.getY() + slot.getHeigth(); // Déplacer pour utiliser le coin haut
+        float y2 = slot.getY() + slot.getHeight(); // Déplacer pour utiliser le coin haut
         float z2 = 1f; // Déplacer pour utiliser le coin arrière
 
         //Tailles du regroupement de blocks:


### PR DESCRIPTION
## Summary
- rename GUI component field `heigth` to `height`
- update constructors and calculations using the height field
- adjust utility methods to call `getHeight`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684010a9b0f883308e11cbce49fdbcf3