### PR TITLE
Add title menu and game state

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" default="true" project-jdk-name="openjdk-22" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="openjdk-22" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
@@ -11,6 +11,7 @@ import fr.rhumun.game.worldcraftopengl.entities.Player;
 import fr.rhumun.game.worldcraftopengl.outputs.audio.AudioManager;
 import fr.rhumun.game.worldcraftopengl.outputs.audio.Sound;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.GraphicModule;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.title_menu.TitleMenuGui;
 import fr.rhumun.game.worldcraftopengl.worlds.World;
 import fr.rhumun.game.worldcraftopengl.worlds.SaveManager;
 import lombok.Getter;
@@ -28,7 +29,7 @@ public class Game {
     //public static String GAME_PATH = "C:\\Users\\eletu\\IdeaProjects\\Worldcraft\\";
     public static String GAME_PATH = "E:\\Devellopement\\Games\\Worldcraft\\";
     public static int SIMULATION_DISTANCE = 6;
-    public static int SHOW_DISTANCE = 25;
+    public static int SHOW_DISTANCE = 16;
     public static int CHUNK_SIZE = 16;
     public static boolean ANTIALIASING = false;
     public static boolean SHOWING_GUIS = true;
@@ -37,6 +38,7 @@ public class Game {
     public static int GUI_ZOOM = 2;
     public static boolean GENERATION = true;
     public static boolean UPDATE_FRUSTRUM = true;
+    public static boolean UPDATE_WORLD_RENDER = true;
     public static boolean ENABLE_VSYNC = false;
     public static boolean GREEDY_MESHING = true;
     public static boolean GL_DEBUG = false;
@@ -62,7 +64,7 @@ public class Game {
     List<Material> materials;
     public static void main(String[] args) {
         Game game = new Game();
-        game.getGraphicModule().getGuiModule().openGUI(new fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.title_menu.TitleMenuGui());
+        game.getGraphicModule().getGuiModule().openGUI(new TitleMenuGui());
         game.getGraphicModule().run();
     }
 
@@ -82,6 +84,7 @@ public class Game {
         this.player = new Player(this);
 
         graphicModule = new GraphicModule(this);
+        graphicModule.init();
     }
 
     public void setPaused(boolean b) {

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
@@ -42,7 +42,7 @@ public class Game {
     public static boolean ENABLE_VSYNC = false;
     public static boolean GREEDY_MESHING = true;
     public static boolean GL_DEBUG = false;
-    public static boolean DEBUG = true;
+    public static boolean DEBUG = false;
     public static int LOD = 4;
     public static final long LAG_SPIKE_LIMIT = 100;
 
@@ -80,7 +80,6 @@ public class Game {
         audioManager = new AudioManager(this);
         audioManager.init();
 
-        this.world = new World();
         this.player = new Player(this);
 
         graphicModule = new GraphicModule(this);
@@ -109,7 +108,11 @@ public class Game {
     }
 
     public void startGame(){
+        this.getGraphicModule().getGuiModule().closeGUI();
+
+        this.world = new World();
         this.world.load();
+        this.graphicModule.initWorldGraphics();
 
         while(!world.isLoaded()){ }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
@@ -26,8 +26,8 @@ public class Game {
 
     public static Game GAME;
 
-    //public static String GAME_PATH = "C:\\Users\\eletu\\IdeaProjects\\Worldcraft\\";
-    public static String GAME_PATH = "E:\\Devellopement\\Games\\Worldcraft\\";
+    public static String GAME_PATH = "C:\\Users\\eletu\\IdeaProjects\\Worldcraft\\";
+    //public static String GAME_PATH = "E:\\Devellopement\\Games\\Worldcraft\\";
     public static int SIMULATION_DISTANCE = 6;
     public static int SHOW_DISTANCE = 16;
     public static int CHUNK_SIZE = 16;
@@ -42,7 +42,7 @@ public class Game {
     public static boolean ENABLE_VSYNC = false;
     public static boolean GREEDY_MESHING = true;
     public static boolean GL_DEBUG = false;
-    public static boolean DEBUG = false;
+    public static boolean DEBUG = true;
     public static int LOD = 4;
     public static final long LAG_SPIKE_LIMIT = 100;
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
@@ -26,8 +26,8 @@ public class Game {
 
     public static Game GAME;
 
-    public static String GAME_PATH = "C:\\Users\\eletu\\IdeaProjects\\Worldcraft\\";
-    //public static String GAME_PATH = "E:\\Devellopement\\Games\\Worldcraft\\";
+    //public static String GAME_PATH = "C:\\Users\\eletu\\IdeaProjects\\Worldcraft\\";
+    public static String GAME_PATH = "E:\\Devellopement\\Games\\Worldcraft\\";
     public static int SIMULATION_DISTANCE = 6;
     public static int SHOW_DISTANCE = 16;
     public static int CHUNK_SIZE = 16;
@@ -110,6 +110,8 @@ public class Game {
     public void startGame(){
         this.getGraphicModule().getGuiModule().closeGUI();
 
+        this.gameState = GameState.RUNNING;
+
         this.world = new World();
         this.world.load();
         this.graphicModule.initWorldGraphics();
@@ -136,8 +138,6 @@ public class Game {
 
         gameLoop = new GameLoop(this, player);
         gameLoop.start();
-
-        this.gameState = GameState.RUNNING;
     }
 
     public void sendMessage(Player player, String message){

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/GameLoop.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/GameLoop.java
@@ -28,7 +28,7 @@ public class GameLoop extends Thread {
     public void run() {
         game.log("Starting GameLoop");
 
-        while (game.isPlaying) {
+        while (game.isPlaying()) {
             long nextTime = time + 1000;
             long currentTime = System.currentTimeMillis();
             long delta = currentTime - previousUpdate;

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/GameState.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/GameState.java
@@ -1,0 +1,7 @@
+package fr.rhumun.game.worldcraftopengl;
+
+public enum GameState {
+    TITLE,
+    RUNNING,
+    PAUSED
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/LoadedChunksManager.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/LoadedChunksManager.java
@@ -31,7 +31,7 @@ public class LoadedChunksManager {
     }
 
     public void updateChunksGradually() {
-        if(!game.isPlaying() || game.isPaused()) return;
+        if(!game.isPlaying() || game.isPaused() || !UPDATE_WORLD_RENDER) return;
 
         World world = player.getLocation().getWorld();
         int centerX = player.getLocation().getChunk().getX();

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/LoadedChunksManager.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/LoadedChunksManager.java
@@ -31,7 +31,7 @@ public class LoadedChunksManager {
     }
 
     public void updateChunksGradually() {
-        if(!game.isPlaying() || game.isPaused) return;
+        if(!game.isPlaying() || game.isPaused()) return;
 
         World world = player.getLocation().getWorld();
         int centerX = player.getLocation().getChunk().getX();

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/textures/Texture.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/textures/Texture.java
@@ -1,9 +1,11 @@
 package fr.rhumun.game.worldcraftopengl.content.textures;
 
 import fr.rhumun.game.worldcraftopengl.Game;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.utils.ButtonTextureMaker;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -92,6 +94,8 @@ public class Texture {
     public static Texture CREATIVE_INVENTORY;
     public static Texture INVENTORY;
     public static Texture BUTTON;
+    public static Texture PLAY_BUTTON;
+    public static Texture QUIT_BUTTON;
 
 
     public static Texture OTTER;
@@ -176,6 +180,8 @@ public class Texture {
         CREATIVE_INVENTORY = new Texture(TextureTypes.GUIS,"hud\\creative-inventory.png");
         INVENTORY = new Texture(TextureTypes.GUIS,"hud\\inventory.png");
         BUTTON = new Texture(TextureTypes.GUIS,"hud\\button.png");
+        PLAY_BUTTON = new Texture(ButtonTextureMaker.create(200, 40), "play_button", 200, 40);
+        QUIT_BUTTON = new Texture(ButtonTextureMaker.create(200, 40), "quit_button", 200, 40);
 
         OTTER = new Texture(TextureTypes.ENTITIES,"entities\\nocsy_otter_v2.png");
     }
@@ -187,10 +193,22 @@ public class Texture {
     }
 
 
-    private final String path;
+    private String path;
     private final String name;
     private final int id;
 
+    private ByteBuffer buffer;
+    private int width;
+    private int height;
+
+    public Texture(ByteBuffer buffer, String name, int width, int height) {
+        this.buffer = buffer;
+        this.name = name;
+        this.width = width;
+        this.height = height;
+        this.id = textures.size();
+        textureByName.put(this.name, this);
+    }
     public Texture(String path){ this(TextureTypes.BLOCKS, path); }
     public Texture(TextureTypes type, String path){
         this.path = path;
@@ -207,6 +225,8 @@ public class Texture {
         textureByName.put(this.name, this);
 
     }
+
+    public boolean isBuffered() { return buffer != null; }
 
     public String getPath(){ return Game.TEXTURES_PATH + this.path; }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/textures/Texture.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/textures/Texture.java
@@ -2,8 +2,10 @@ package fr.rhumun.game.worldcraftopengl.content.textures;
 
 import fr.rhumun.game.worldcraftopengl.Game;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.utils.ButtonTextureMaker;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.utils.TextureUtils;
 import lombok.Getter;
 import lombok.Setter;
+import org.w3c.dom.Text;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -88,14 +90,14 @@ public class Texture {
     public static Texture CALCITE_BRICK;
 
 
+    public static Texture PLAY_BUTTON;
+    public static Texture QUIT_BUTTON;
     public static Texture CROSSHAIR;
     public static Texture HOTBAR;
     public static Texture SELECTED_SLOT;
     public static Texture CREATIVE_INVENTORY;
     public static Texture INVENTORY;
     public static Texture BUTTON;
-    public static Texture PLAY_BUTTON;
-    public static Texture QUIT_BUTTON;
 
 
     public static Texture OTTER;
@@ -174,15 +176,14 @@ public class Texture {
         JACK_O_LANTERN = new Texture("jack_o_lantern.png");
         SNOWY_GRASS = new Texture("snowy_grass.png");
 
+        PLAY_BUTTON = new Texture(TextureTypes.GUIS, ButtonTextureMaker.create(200, 40), "play_button", 200, 40);
+        QUIT_BUTTON = new Texture(TextureTypes.GUIS, ButtonTextureMaker.create(200, 40), "quit_button", 200, 40);
         CROSSHAIR = new Texture(TextureTypes.GUIS,"hud\\crosshair.png");
         HOTBAR = new Texture(TextureTypes.GUIS,"hud\\hotbar.png");
         SELECTED_SLOT = new Texture(TextureTypes.GUIS,"hud\\hotbar_selection.png");
         CREATIVE_INVENTORY = new Texture(TextureTypes.GUIS,"hud\\creative-inventory.png");
         INVENTORY = new Texture(TextureTypes.GUIS,"hud\\inventory.png");
         BUTTON = new Texture(TextureTypes.GUIS,"hud\\button.png");
-        PLAY_BUTTON = new Texture(ButtonTextureMaker.create(200, 40), "play_button", 200, 40);
-        QUIT_BUTTON = new Texture(ButtonTextureMaker.create(200, 40), "quit_button", 200, 40);
-
         OTTER = new Texture(TextureTypes.ENTITIES,"entities\\nocsy_otter_v2.png");
     }
 
@@ -201,13 +202,14 @@ public class Texture {
     private int width;
     private int height;
 
-    public Texture(ByteBuffer buffer, String name, int width, int height) {
+    public Texture(TextureTypes type, ByteBuffer buffer, String name, int width, int height) {
         this.buffer = buffer;
         this.name = name;
         this.width = width;
         this.height = height;
         this.id = textures.size();
         textureByName.put(this.name, this);
+        type.add(this);
     }
     public Texture(String path){ this(TextureTypes.BLOCKS, path); }
     public Texture(TextureTypes type, String path){

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/textures/Texture.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/textures/Texture.java
@@ -2,15 +2,12 @@ package fr.rhumun.game.worldcraftopengl.content.textures;
 
 import fr.rhumun.game.worldcraftopengl.Game;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.utils.ButtonTextureMaker;
-import fr.rhumun.game.worldcraftopengl.outputs.graphic.utils.TextureUtils;
 import lombok.Getter;
 import lombok.Setter;
-import org.w3c.dom.Text;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map;
 
 @Getter
 @Setter
@@ -89,15 +86,15 @@ public class Texture {
     public static Texture SNOWY_GRASS;
     public static Texture CALCITE_BRICK;
 
-
-    public static Texture PLAY_BUTTON;
-    public static Texture QUIT_BUTTON;
     public static Texture CROSSHAIR;
     public static Texture HOTBAR;
     public static Texture SELECTED_SLOT;
     public static Texture CREATIVE_INVENTORY;
     public static Texture INVENTORY;
-    public static Texture BUTTON;
+    public static Texture SQUARE_BUTTON;
+    public static Texture DEFAULT_BUTTON;
+    public static Texture DEFAULT_BUTTON_HOVERED;
+    public static Texture DEFAULT_BUTTON_UNACTIVE;
 
 
     public static Texture OTTER;
@@ -176,14 +173,16 @@ public class Texture {
         JACK_O_LANTERN = new Texture("jack_o_lantern.png");
         SNOWY_GRASS = new Texture("snowy_grass.png");
 
-        PLAY_BUTTON = new Texture(TextureTypes.GUIS, ButtonTextureMaker.create(200, 40), "play_button", 200, 40);
-        QUIT_BUTTON = new Texture(TextureTypes.GUIS, ButtonTextureMaker.create(200, 40), "quit_button", 200, 40);
         CROSSHAIR = new Texture(TextureTypes.GUIS,"hud\\crosshair.png");
         HOTBAR = new Texture(TextureTypes.GUIS,"hud\\hotbar.png");
         SELECTED_SLOT = new Texture(TextureTypes.GUIS,"hud\\hotbar_selection.png");
         CREATIVE_INVENTORY = new Texture(TextureTypes.GUIS,"hud\\creative-inventory.png");
         INVENTORY = new Texture(TextureTypes.GUIS,"hud\\inventory.png");
-        BUTTON = new Texture(TextureTypes.GUIS,"hud\\button.png");
+        SQUARE_BUTTON = new Texture(TextureTypes.GUIS,"hud\\button.png");
+        DEFAULT_BUTTON = new Texture(TextureTypes.GUIS, "hud\\buttons\\button.png");
+        DEFAULT_BUTTON_HOVERED = new Texture(TextureTypes.GUIS, "hud\\buttons\\hovered.png");
+        DEFAULT_BUTTON_UNACTIVE = new Texture(TextureTypes.GUIS, "hud\\buttons\\unactive.png");
+
         OTTER = new Texture(TextureTypes.ENTITIES,"entities\\nocsy_otter_v2.png");
     }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/controls/Control.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/controls/Control.java
@@ -25,11 +25,11 @@ public abstract class Control {
     public Control(){ this(false, false); }
 
     public void testOnKeyPressed(Player player){
-        if(game.getGameState() == GameState.RUNNING || (canExecuteInPause && game.getGameState() == GameState.PAUSED))
+        if(game.getGameState() == GameState.RUNNING || canExecuteInPause && game.isPaused())
             onKeyPressed(player);
     }
     public void testOnKeyReleased(Player player){
-        if(game.getGameState() == GameState.RUNNING || (canExecuteInPause && game.getGameState() == GameState.PAUSED))
+        if(game.getGameState() == GameState.RUNNING || (canExecuteInPause && game.getGameState() != GameState.PAUSED))
             onKeyReleased(player);
     }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/controls/Control.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/controls/Control.java
@@ -2,6 +2,7 @@ package fr.rhumun.game.worldcraftopengl.controls;
 
 import fr.rhumun.game.worldcraftopengl.Game;
 import fr.rhumun.game.worldcraftopengl.entities.Player;
+import fr.rhumun.game.worldcraftopengl.GameState;
 import lombok.Getter;
 
 import static fr.rhumun.game.worldcraftopengl.Game.GAME;
@@ -24,10 +25,12 @@ public abstract class Control {
     public Control(){ this(false, false); }
 
     public void testOnKeyPressed(Player player){
-        if(!game.isPaused() || canExecuteInPause) onKeyPressed(player);
+        if(game.getGameState() == GameState.RUNNING || (canExecuteInPause && game.getGameState() == GameState.PAUSED))
+            onKeyPressed(player);
     }
     public void testOnKeyReleased(Player player){
-        if(!game.isPaused() || canExecuteInPause) onKeyReleased(player);
+        if(game.getGameState() == GameState.RUNNING || (canExecuteInPause && game.getGameState() == GameState.PAUSED))
+            onKeyReleased(player);
     }
 
     public abstract void onKeyPressed(Player player);

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/controls/Controls.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/controls/Controls.java
@@ -26,7 +26,8 @@ public enum Controls {
     SHOW_TRIANGLES(new ShowTrianlges()),
     INVENTORY(new OpenInventory()),
     ENTER(new Enter()),
-    DROP_ITEM(new DropItem());
+    DROP_ITEM(new DropItem()),
+    WORLD_RENDER_BOOL(new WorldRendererBool());
 
     static final HashMap<Integer, Controls> KEYS = new HashMap<>();
 
@@ -59,6 +60,7 @@ public enum Controls {
         add(GLFW_KEY_E, INVENTORY);
         add(GLFW_KEY_ENTER, ENTER);
         add(GLFW_KEY_Q, DROP_ITEM);
+        add(GLFW_KEY_F5, WORLD_RENDER_BOOL);
     }
 
     private static void add(int code, Controls control){ KEYS.put(code, control); }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/controls/WorldRendererBool.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/controls/WorldRendererBool.java
@@ -1,0 +1,16 @@
+package fr.rhumun.game.worldcraftopengl.controls;
+
+import fr.rhumun.game.worldcraftopengl.Game;
+import fr.rhumun.game.worldcraftopengl.entities.Player;
+
+public class WorldRendererBool extends Control {
+    @Override
+    public void onKeyPressed(Player player) {
+        Game.UPDATE_WORLD_RENDER = !Game.UPDATE_WORLD_RENDER;
+    }
+
+    @Override
+    public void onKeyReleased(Player player) {
+
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GraphicModule.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GraphicModule.java
@@ -1,6 +1,7 @@
 package fr.rhumun.game.worldcraftopengl.outputs.graphic;
 
 import fr.rhumun.game.worldcraftopengl.*;
+import fr.rhumun.game.worldcraftopengl.GameState;
 import fr.rhumun.game.worldcraftopengl.controls.*;
 import fr.rhumun.game.worldcraftopengl.controls.event.CursorEvent;
 import fr.rhumun.game.worldcraftopengl.controls.event.KeyEvent;
@@ -318,6 +319,7 @@ public class GraphicModule {
     }
 
     private void update() {
+        if (game.getGameState() != GameState.RUNNING) return;
         if (!areChunksUpdated) {
             loadedChunks = new LinkedHashSet<>(player.getLoadedChunksManager().getChunksToRender());
             loadedFarChunks = new LinkedHashSet<>(player.getLoadedChunksManager().getChunksToRenderLight());
@@ -344,6 +346,7 @@ public class GraphicModule {
     }
 
     private void updateFarChunks() {
+        if (game.getGameState() != GameState.RUNNING) return;
         if (!areChunksUpdated) {
             loadedChunks = new LinkedHashSet<>(player.getLoadedChunksManager().getChunksToRender());
             loadedFarChunks = new LinkedHashSet<>(player.getLoadedChunksManager().getChunksToRenderLight());

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GraphicModule.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GraphicModule.java
@@ -98,7 +98,6 @@ public class GraphicModule {
     }
 
     public void run() {
-        init();
         try {
             loop();
         } catch (Exception e) {
@@ -110,7 +109,7 @@ public class GraphicModule {
         System.exit(0);
     }
 
-    private void init() {
+    public void init() {
         initGLFW();
         createWindow();
         setupOpenGL();
@@ -271,7 +270,7 @@ public class GraphicModule {
 
         Matrix4f viewMatrix = new Matrix4f().lookAt(camera.getPos(), camera.getLookPoint(), camera.getUp());
 
-        if (UPDATE_FRUSTRUM) {
+        if (UPDATE_FRUSTRUM && UPDATE_WORLD_RENDER) {
             Matrix4f combinedMatrix = new Matrix4f().mul(projectionMatrix).mul(viewMatrix);
             frustumIntersection = new FrustumIntersection(combinedMatrix);
         }
@@ -295,7 +294,7 @@ public class GraphicModule {
             if (game.isPaused() != isPaused) setPaused(game.isPaused());
             if (game.isShowingTriangles() != isShowingTriangles) setShowingTriangles(game.isShowingTriangles());
 
-            updateWaterTime();
+            //updateWaterTime();
             updateViewMatrix();
 
             glUseProgram(ShaderManager.FAR_SHADER.id);
@@ -320,7 +319,7 @@ public class GraphicModule {
 
     private void update() {
         if (game.getGameState() != GameState.RUNNING) return;
-        if (!areChunksUpdated) {
+        if (!areChunksUpdated && UPDATE_WORLD_RENDER) {
             loadedChunks = new LinkedHashSet<>(player.getLoadedChunksManager().getChunksToRender());
             loadedFarChunks = new LinkedHashSet<>(player.getLoadedChunksManager().getChunksToRenderLight());
             areChunksUpdated = true;
@@ -347,7 +346,7 @@ public class GraphicModule {
 
     private void updateFarChunks() {
         if (game.getGameState() != GameState.RUNNING) return;
-        if (!areChunksUpdated) {
+        if (!areChunksUpdated && UPDATE_WORLD_RENDER) {
             loadedChunks = new LinkedHashSet<>(player.getLoadedChunksManager().getChunksToRender());
             loadedFarChunks = new LinkedHashSet<>(player.getLoadedChunksManager().getChunksToRenderLight());
             areChunksUpdated = true;

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GraphicModule.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GraphicModule.java
@@ -83,7 +83,7 @@ public class GraphicModule {
 
     // == State ==
     private boolean isInitialized = false;
-    private boolean isPaused = false;
+    private boolean isPaused = true;
     public boolean isShowingTriangles = false;
 
     public GraphicModule(Game game) {
@@ -142,7 +142,7 @@ public class GraphicModule {
         glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
         glfwWindowHint(GLFW_SAMPLES, 3);
 
-        window = glfwCreateWindow(startWidth, startHeight, "WorldCraft OpenGL", NULL, NULL);
+        window = glfwCreateWindow(startWidth, startHeight, "WorldCraft", NULL, NULL);
         if (window == NULL) throw new RuntimeException("Failed to create GLFW window");
 
         glfwSetMouseButtonCallback(window, new MouseClickEvent(game));

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GuiModule.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GuiModule.java
@@ -171,8 +171,6 @@ public class GuiModule {
     public void rightClick(Player player) {
         if(!hasGUIOpened()) return;
 
-        System.out.println("RIGHT CLICK");
-
 //        for(Component component : this.gui.getComponents()){
 //            if(component instanceof Button button) {
 //                if(component.isCursorIn())
@@ -182,10 +180,7 @@ public class GuiModule {
     }
 
     public void leftClick(Player player) {
-        System.out.println("LEFT CLICK");
-
         if(!hasGUIOpened()) return;
-        System.out.println("LEFT CLICK 2");
 
         for(Component component : this.gui.getComponents()){
             if(component instanceof Button button) {

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GuiModule.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GuiModule.java
@@ -182,7 +182,10 @@ public class GuiModule {
     }
 
     public void leftClick(Player player) {
+        System.out.println("LEFT CLICK");
+
         if(!hasGUIOpened()) return;
+        System.out.println("LEFT CLICK 2");
 
         for(Component component : this.gui.getComponents()){
             if(component instanceof Button button) {

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Button.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Button.java
@@ -9,8 +9,10 @@ import lombok.Setter;
 public abstract class Button extends Component {
     private boolean hovered = false;
     private boolean clicked = false;
+
     public Button(int x, int y, int width, int height, Texture texture, Gui container) {
         super(x, y, width, height, texture, container);
+
     }
 
     public abstract void onClick(Player player) ;

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Button.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Button.java
@@ -10,10 +10,52 @@ public abstract class Button extends Component {
     private boolean hovered = false;
     private boolean clicked = false;
 
-    public Button(int x, int y, int width, int height, Texture texture, Gui container) {
-        super(x, y, width, height, texture, container);
+    private Texture normal, hoverTexture, unactiveTexture;
+    private final TextComponent text = new TextComponent(0, 0, "", this);
 
+    public Button(int x, int y, Gui container, String text) {
+        this(x, y, 200, 40, Texture.DEFAULT_BUTTON, Texture.DEFAULT_BUTTON_HOVERED, Texture.DEFAULT_BUTTON_UNACTIVE, container);
+        this.text.setText(text);
+    }
+
+    public Button(int x, int y, int width, int height, Gui container) {
+        this(x, y, width, height, Texture.DEFAULT_BUTTON, Texture.DEFAULT_BUTTON_HOVERED, Texture.DEFAULT_BUTTON_UNACTIVE, container);
+    }
+
+    public Button(int x, int y, int width, int height, Texture texture, Gui container) {
+        this(x, y, width, height, texture, texture, texture, container);
+    }
+
+    public Button(int x, int y, int width, int height, Texture texture, Texture hovered, Texture unactive, Gui container) {
+        super(x, y, width, height, texture, container);
+        this.normal = texture;
+        this.hoverTexture = hovered;
+        this.unactiveTexture = unactive;
+
+        this.setAlignCenter(true);
+        this.addComponent(text);
     }
 
     public abstract void onClick(Player player) ;
+
+    @Override
+    public void update() {
+        this.centerText();
+
+        boolean isCursorIn = this.isCursorIn();
+
+        if(isCursorIn && !hovered) {
+            this.set2DTexture(hoverTexture);
+            this.setHovered(true);
+        }
+        else if(!isCursorIn && hovered){
+            this.set2DTexture(normal);
+            this.setHovered(false);
+        }
+
+    }
+
+    private void centerText() {
+        this.text.set2DCoordinates(0, 0);
+    }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Component.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Component.java
@@ -26,8 +26,8 @@ public abstract class Component{
 
     private int x;
     private int y;
-    private final int width;
-    private final int height;
+    private int width;
+    private int height;
     private Texture texture;
     private Component container;
     private GuiModule guiModule;
@@ -35,6 +35,8 @@ public abstract class Component{
 
     private float[] vertices;
     private boolean isInitialized = false;
+
+    private boolean alignCenter = false;
 
     // Indices pour dessiner un quad avec deux triangles
     private int[] indices;
@@ -55,9 +57,15 @@ public abstract class Component{
 
     public boolean hasContainer(){ return this.container != null; }
 
-    public int getX(){ return this.x*((this instanceof Gui) ? 1 : GUI_ZOOM) + ((this.hasContainer()) ? this.container.getX() : 0); }
+    public int getX(){
+        return this.x*((this instanceof Gui) ? 1 : GUI_ZOOM) + ((this.hasContainer()) ? this.container.getX() : 0)
+                + ((this.hasContainer() && this.container.alignCenter) ? this.container.width/2 - this.width/2 : 0 );
+    }
 
-    public int getY(){ return this.y*((this instanceof Gui) ? 1 : GUI_ZOOM) + ((this.hasContainer()) ? this.container.getY() : 0); }
+    public int getY(){
+        return this.y*((this instanceof Gui) ? 1 : GUI_ZOOM) + ((this.hasContainer()) ? this.container.getY() : 0)
+                + ((this.hasContainer() && this.container.alignCenter) ? this.container.height/2 - this.height/2 : 0 );
+    }
 
     public List<Component> getComponents(){
         if(this.components.isEmpty()) return new ArrayList<>();

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Component.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Component.java
@@ -7,6 +7,9 @@ import fr.rhumun.game.worldcraftopengl.outputs.graphic.utils.TextureUtils;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 import static fr.rhumun.game.worldcraftopengl.Game.GUI_ZOOM;
 import static org.lwjgl.opengl.GL11.*;
@@ -26,8 +29,9 @@ public abstract class Component{
     private final int width;
     private final int height;
     private Texture texture;
-    private Gui container;
+    private Component container;
     private GuiModule guiModule;
+    private final List<Component> components = new ArrayList<>();
 
     private float[] vertices;
     private boolean isInitialized = false;
@@ -35,7 +39,7 @@ public abstract class Component{
     // Indices pour dessiner un quad avec deux triangles
     private int[] indices;
 
-    public Component(int x, int y, int width, int height, Texture texture, Gui container){
+    public Component(int x, int y, int width, int height, Texture texture, Component container){
 
         this.x = x;
         this.y = y;
@@ -54,6 +58,20 @@ public abstract class Component{
     public int getX(){ return this.x*((this instanceof Gui) ? 1 : GUI_ZOOM) + ((this.hasContainer()) ? this.container.getX() : 0); }
 
     public int getY(){ return this.y*((this instanceof Gui) ? 1 : GUI_ZOOM) + ((this.hasContainer()) ? this.container.getY() : 0); }
+
+    public List<Component> getComponents(){
+        if(this.components.isEmpty()) return new ArrayList<>();
+
+        List<Component> components = new ArrayList<>(this.components);
+        for(Component component : this.components)
+            if(component.containsComponents()) components.addAll(component.getComponents());
+
+        return components;
+    }
+
+    private boolean containsComponents() {
+        return !this.components.isEmpty();
+    }
 
     public boolean isCursorIn(){
         int x = getGuiModule().getCursorX();
@@ -128,17 +146,18 @@ public abstract class Component{
         if(!isInitialized) this.init();
 
         update();
-        if(indices == null || vertices == null) {
-            return;
+        if(indices != null && vertices != null) {
+            glUseProgram(this.getShader());
+            glBindVertexArray(this.getVAO());
+            glBindBuffer(GL_ARRAY_BUFFER, this.getVBO());
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.getEBO());
+
+            glDrawElements(GL_TRIANGLES, indices.length, GL_UNSIGNED_INT, 0);
+            glBindVertexArray(0);
         }
 
-        glUseProgram(this.getShader());
-        glBindVertexArray(this.getVAO());
-        glBindBuffer(GL_ARRAY_BUFFER, this.getVBO());
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.getEBO());
-
-        glDrawElements(GL_TRIANGLES, indices.length, GL_UNSIGNED_INT, 0);
-        glBindVertexArray(0);
+        if(!this.components.isEmpty())
+            for(Component component : this.getComponents()) component.render();
     }
 
     public int getShader() {
@@ -171,6 +190,10 @@ public abstract class Component{
     }
 
     public boolean hasTexture(){ return this.texture != null; }
+
+    public void addComponent(Component component){
+        this.components.add(component);
+    }
 
 
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Gui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Gui.java
@@ -16,10 +16,6 @@ import static fr.rhumun.game.worldcraftopengl.Game.GUI_ZOOM;
 @Getter @Setter
 public class Gui extends Component {
 
-    //private final GuiRenderer renderer;
-    private final GuiModule guiModule;
-
-    private final List<Component> components = new ArrayList<>();
     private List<Slot> slots = new ArrayList<>();
     @Setter
     private ItemContainer itemContainer;
@@ -28,17 +24,10 @@ public class Gui extends Component {
 
     public Gui(int x, int y, int width, int height, Texture texture, Gui container){
         super(x, y, width, height, texture, container);
-        //this.renderer = new GuiRenderer(x, y, x+width, y+height, texture);
-        this.guiModule = GAME.getGraphicModule().getGuiModule();
     }
 
     public Gui(int x, int y, int width, int height, Texture texture){
         this(x, y, width, height, texture, null);
-    }
-
-    public void render(){
-        super.render();
-        for(Component component : this.components) component.render();
     }
 
     @Override
@@ -46,38 +35,30 @@ public class Gui extends Component {
 
     }
 
-    public List<Component> getComponents(){
-        List<Component> components = new ArrayList<>(this.components);
-        for(Component component : this.components)
-            if(component instanceof Gui gui) components.addAll(gui.getComponents());
-
-        return components;
-    }
-
     public Image createImage(int x, int y, int width, int height, Texture texture){
         Image image = new Image(x, y, width, height, texture, this);
 
-        this.components.add(image);
+        this.addComponent(image);
         return image;
     }
 
     public TextComponent addText(int x, int y, String text) {
         TextComponent textC = new TextComponent(x, y, text, this);
 
-        this.components.add(textC);
+        this.addComponent(textC);
         return textC;
     }
 
 
     public void addButton(Button button) {
-        this.components.add(button);
+        this.addComponent(button);
     }
 
     public Slot createSlot(int x, int y, int size){
         Slot slot = new Slot(x, y, size, slots.size(), this);
 
         this.slots.add(slot);
-        this.components.add(slot);
+        this.addComponent(slot);
         return slot;
     }
 
@@ -85,7 +66,7 @@ public class Gui extends Component {
         Slot slot = new Slot(x, y, slots.size(), this);
 
         this.slots.add(slot);
-        this.components.add(slot);
+        this.addComponent(slot);
         return slot;
     }
 
@@ -94,7 +75,7 @@ public class Gui extends Component {
         ClickableSlot slot = new ClickableSlot(x, y, size, slots.size(), this);
 
         this.slots.add(slot);
-        this.components.add(slot);
+        this.addComponent(slot);
         return slot;
     }
 
@@ -102,7 +83,7 @@ public class Gui extends Component {
         CreativeSlot slot = new CreativeSlot(x, y, size, slots.size(), this);
 
         this.slots.add(slot);
-        this.components.add(slot);
+        this.addComponent(slot);
         return slot;
     }
 
@@ -112,7 +93,7 @@ public class Gui extends Component {
     public InventoryGUI addInventory(int x, int y, float ratio){
         InventoryGUI gui = new InventoryGUI(GUI_ZOOM*x, GUI_ZOOM*y, ratio, this);
 
-        this.components.add(gui);
+        this.addComponent(gui);
         return gui;
     }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Slot.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Slot.java
@@ -35,11 +35,11 @@ public class Slot extends Button {
     }
 
     public Item getItem(){
-        return this.getContainer().getItemContainer().getItems()[id];
+        return ((Gui)this.getContainer()).getItemContainer().getItems()[id];
     }
 
     public void setItem(Item item){
-        this.getContainer().getItemContainer().setItem(id, item);
+        ((Gui)this.getContainer()).getItemContainer().setItem(id, item);
     }
 
     @Override

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/TextComponent.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/TextComponent.java
@@ -20,13 +20,13 @@ public class TextComponent extends Component {
     private final float[] rgba = new float[4];
     private int height =32;
 
-    public TextComponent(int x, int y, String text, Gui container) {
+    public TextComponent(int x, int y, String text, Component container) {
         this(x, y, text, 255, 255, 255, 255, container);
     }
-    public TextComponent(int x, int y, String text, int r, int g, int b, Gui container) {
+    public TextComponent(int x, int y, String text, int r, int g, int b, Component container) {
         this(x, y, text, r, g, b, 255, container);
     }
-    public TextComponent(int x, int y, String text, int r, int g, int b, int a, Gui container) {
+    public TextComponent(int x, int y, String text, int r, int g, int b, int a, Component container) {
         super(x, y, 0, 0, null, container);
         this.text = text;
         this.setRGBA(r, g, b, a);

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/TextComponent.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/TextComponent.java
@@ -18,7 +18,7 @@ public class TextComponent extends Component {
     private String text;
     private String showedText;
     private final float[] rgba = new float[4];
-    private int height =32;
+    private int defaultHeight = 32;
 
     public TextComponent(int x, int y, String text, Component container) {
         this(x, y, text, 255, 255, 255, 255, container);
@@ -70,6 +70,9 @@ public class TextComponent extends Component {
     public int getTextureArray(){ return FontLoader.TEXTURES_ARRAY; }
     @Override
     public void updateVertices() {
+        super.setWidth(0);
+        super.setHeight(defaultHeight);
+
         if (text == null || text.isEmpty()) return;
 
         List<Float> verticesList = new ArrayList<>();
@@ -102,7 +105,7 @@ public class TextComponent extends Component {
             float yOffset = glyph.getYOffset() * Game.GUI_ZOOM;
             float advance = glyph.getAdvance();
 
-            int startY = this.height - glyphHeight;
+            int startY = this.defaultHeight - glyphHeight;
 
             // Coordonnées de texture dans l'atlas
             float xStart = 0;//glyph.getXStart();
@@ -153,6 +156,15 @@ public class TextComponent extends Component {
             xCursor += advance/48; // Avancer le curseur horizontal
         }
 
+        if (this.hasContainer() && this.getContainer().isAlignCenter()) {
+            this.setWidth(xCursor - getX());
+            this.setHeight(Math.max(this.getHeight(), yCursor + defaultHeight - getY()));
+
+            for(int i= 0; i<verticesList.size(); i+=6){
+                verticesList.set(i, verticesList.get(i) - this.getWidth()/2);
+            }
+        }
+
         // Convertir en tableaux
         float[] verticesArray = new float[verticesList.size()];
         for (int i = 0; i < verticesArray.length; i++) verticesArray[i] = verticesList.get(i);
@@ -164,6 +176,7 @@ public class TextComponent extends Component {
 
         if (isInitialized()) updateVAO();
         this.showedText = text;
+
     }
 
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/creative_inventory/SlabButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/creative_inventory/SlabButton.java
@@ -10,7 +10,7 @@ import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.items_containers.Cre
 public class SlabButton extends Button {
 
     public SlabButton(int x, int y, Gui container) {
-        super(x, y, 48, 46, Texture.BUTTON, container);
+        super(x, y, 48, 46, Texture.SQUARE_BUTTON, container);
     }
 
     @Override

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/QuitButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/QuitButton.java
@@ -13,7 +13,7 @@ public class QuitButton extends Button {
     private final TextComponent label;
 
     public QuitButton(int x, int y, Gui container) {
-        super(x, y, 100, 20, Texture.BUTTON, container);
+        super(x, y, 200, 40, Texture.QUIT_BUTTON, container);
         this.label = container.addText(x + 30, y + 6, "Quitter");
     }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/QuitButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/QuitButton.java
@@ -10,11 +10,9 @@ import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 
 public class QuitButton extends Button {
 
-    private final TextComponent label;
-
     public QuitButton(int x, int y, Gui container) {
         super(x, y, 200, 40, Texture.QUIT_BUTTON, container);
-        this.label = container.addText(x + 30, y + 6, "Quitter");
+        this.addComponent(new TextComponent(30, 6, "Quitter", this));
     }
 
     @Override

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/QuitButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/QuitButton.java
@@ -4,13 +4,17 @@ import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
 import fr.rhumun.game.worldcraftopengl.entities.Player;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Button;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Gui;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.TextComponent;
 
 import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 
 public class QuitButton extends Button {
 
+    private final TextComponent label;
+
     public QuitButton(int x, int y, Gui container) {
         super(x, y, 100, 20, Texture.BUTTON, container);
+        this.label = container.addText(x + 30, y + 6, "Quitter");
     }
 
     @Override

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/QuitButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/QuitButton.java
@@ -11,8 +11,7 @@ import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 public class QuitButton extends Button {
 
     public QuitButton(int x, int y, Gui container) {
-        super(x, y, 200, 40, Texture.QUIT_BUTTON, container);
-        this.addComponent(new TextComponent(30, 6, "Quitter", this));
+        super(x, y, container, "Quitter");
     }
 
     @Override
@@ -20,8 +19,4 @@ public class QuitButton extends Button {
         GAME.closeGame();
     }
 
-    @Override
-    public void update() {
-
-    }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
@@ -10,11 +10,10 @@ import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 
 public class PlayButton extends Button {
 
-    private final TextComponent label;
 
     public PlayButton(int x, int y, Gui container) {
         super(x, y, 200, 40, Texture.PLAY_BUTTON, container);
-        this.label = container.addText(x + 35, y + 6, "Jouer");
+        this.addComponent(new TextComponent(35, 6, "Jouer", this));
     }
 
     @Override

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
@@ -1,0 +1,20 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.title_menu;
+
+import fr.rhumun.game.worldcraftopengl.entities.Player;
+import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Button;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Gui;
+
+import static fr.rhumun.game.worldcraftopengl.Game.GAME;
+
+public class PlayButton extends Button {
+
+    public PlayButton(int x, int y, Gui container) {
+        super(x, y, 100, 20, Texture.BUTTON, container);
+    }
+
+    @Override
+    public void onClick(Player player) {
+        GAME.startGame();
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
@@ -13,7 +13,7 @@ public class PlayButton extends Button {
     private final TextComponent label;
 
     public PlayButton(int x, int y, Gui container) {
-        super(x, y, 100, 20, Texture.BUTTON, container);
+        super(x, y, 200, 40, Texture.PLAY_BUTTON, container);
         this.label = container.addText(x + 35, y + 6, "Jouer");
     }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
@@ -4,13 +4,22 @@ import fr.rhumun.game.worldcraftopengl.entities.Player;
 import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Button;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Gui;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.TextComponent;
 
 import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 
 public class PlayButton extends Button {
 
+    private final TextComponent label;
+
     public PlayButton(int x, int y, Gui container) {
         super(x, y, 100, 20, Texture.BUTTON, container);
+        this.label = container.addText(x + 35, y + 6, "Jouer");
+    }
+
+    @Override
+    public void update() {
+
     }
 
     @Override

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
@@ -12,13 +12,7 @@ public class PlayButton extends Button {
 
 
     public PlayButton(int x, int y, Gui container) {
-        super(x, y, 200, 40, Texture.PLAY_BUTTON, container);
-        this.addComponent(new TextComponent(35, 6, "Jouer", this));
-    }
-
-    @Override
-    public void update() {
-
+        super(x, y, container, "Jouer");
     }
 
     @Override

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/TitleMenuGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/TitleMenuGui.java
@@ -1,15 +1,19 @@
 package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.title_menu;
 
+import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.GraphicModule;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.CenteredGUI;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.pause_menu.QuitButton;
 
 public class TitleMenuGui extends CenteredGUI {
 
     public TitleMenuGui() {
-        super(500, 500, null);
+            super(500, 500, Texture.PLANKS);
 
-        this.addText(200, 50, "Title Menu");
-        this.addButton(new PlayButton(200, 250, this));
-        this.addButton(new QuitButton(200, 350, this));
+        this.addText(0, -200, "Title Menu");
+        this.addButton(new PlayButton(0, 0, this));
+        this.addButton(new QuitButton(0, 80, this));
+
+        this.setAlignCenter(true);
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/TitleMenuGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/TitleMenuGui.java
@@ -1,0 +1,15 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.title_menu;
+
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.CenteredGUI;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.pause_menu.QuitButton;
+
+public class TitleMenuGui extends CenteredGUI {
+
+    public TitleMenuGui() {
+        super(500, 500, null);
+
+        this.addText(200, 50, "Title Menu");
+        this.addButton(new PlayButton(200, 250, this));
+        this.addButton(new QuitButton(200, 350, this));
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/ButtonTextureMaker.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/ButtonTextureMaker.java
@@ -1,5 +1,6 @@
 package fr.rhumun.game.worldcraftopengl.outputs.graphic.utils;
 
+import fr.rhumun.game.worldcraftopengl.Game;
 import org.lwjgl.BufferUtils;
 
 import java.nio.ByteBuffer;
@@ -22,6 +23,8 @@ public final class ButtonTextureMaker {
      * @return buffer containing RGBA pixels
      */
     public static ByteBuffer create(int width, int height) {
+        Game.GAME.debug("Creating one button texture...");
+
         ByteBuffer buffer = BufferUtils.createByteBuffer(width * height * 4);
         Random random = new Random();
         for (int y = 0; y < height; y++) {

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/ButtonTextureMaker.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/ButtonTextureMaker.java
@@ -4,7 +4,12 @@ import fr.rhumun.game.worldcraftopengl.Game;
 import org.lwjgl.BufferUtils;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Random;
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
 
 /**
  * Utility class to generate simple button textures.
@@ -31,14 +36,44 @@ public final class ButtonTextureMaker {
             for (int x = 0; x < width; x++) {
                 boolean border = x < 2 || y < 2 || x >= width - 2 || y >= height - 2;
                 if (border) {
-                    buffer.put((byte) 0).put((byte) 0).put((byte) 0).put((byte) 255);
+                    buffer.put((byte) 255).put((byte) 0).put((byte) 0).put((byte) 255);
                 } else {
                     int g = 200 + random.nextInt(30);
                     buffer.put((byte) g).put((byte) g).put((byte) g).put((byte) 255);
                 }
             }
         }
-        buffer.flip();
+
         return buffer;
     }
+
+    public static void saveBufferToImage(ByteBuffer buffer, int width, int height, String filePath) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int index = (y * width + x) * 4;
+
+                int r = buffer.get(index) & 0xFF;
+                int g = buffer.get(index + 1) & 0xFF;
+                int b = buffer.get(index + 2) & 0xFF;
+                int a = buffer.get(index + 3) & 0xFF;
+
+                int rgba = ((a & 0xFF) << 24) |
+                        ((r & 0xFF) << 16) |
+                        ((g & 0xFF) << 8)  |
+                        (b & 0xFF);
+
+                image.setRGB(x, y, rgba);
+            }
+        }
+
+        try {
+            ImageIO.write(image, "png", new File(filePath));
+            System.out.println("Image sauvegardée : " + filePath);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/ButtonTextureMaker.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/ButtonTextureMaker.java
@@ -36,9 +36,9 @@ public final class ButtonTextureMaker {
             for (int x = 0; x < width; x++) {
                 boolean border = x < 2 || y < 2 || x >= width - 2 || y >= height - 2;
                 if (border) {
-                    buffer.put((byte) 255).put((byte) 0).put((byte) 0).put((byte) 255);
+                    buffer.put((byte) 0).put((byte) 0).put((byte) 0).put((byte) 255);
                 } else {
-                    int g = 200 + random.nextInt(30);
+                    int g = 150 + random.nextInt(30);
                     buffer.put((byte) g).put((byte) g).put((byte) g).put((byte) 255);
                 }
             }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/ButtonTextureMaker.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/ButtonTextureMaker.java
@@ -1,0 +1,41 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.utils;
+
+import org.lwjgl.BufferUtils;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+/**
+ * Utility class to generate simple button textures.
+ * It creates a buffer containing a two pixels black border with
+ * a subtle light grey filling.
+ */
+public final class ButtonTextureMaker {
+
+    private ButtonTextureMaker() { }
+
+    /**
+     * Creates the pixel buffer for a button texture.
+     *
+     * @param width  width in pixels
+     * @param height height in pixels
+     * @return buffer containing RGBA pixels
+     */
+    public static ByteBuffer create(int width, int height) {
+        ByteBuffer buffer = BufferUtils.createByteBuffer(width * height * 4);
+        Random random = new Random();
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                boolean border = x < 2 || y < 2 || x >= width - 2 || y >= height - 2;
+                if (border) {
+                    buffer.put((byte) 0).put((byte) 0).put((byte) 0).put((byte) 255);
+                } else {
+                    int g = 200 + random.nextInt(30);
+                    buffer.put((byte) g).put((byte) g).put((byte) g).put((byte) 255);
+                }
+            }
+        }
+        buffer.flip();
+        return buffer;
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/TextureUtils.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/TextureUtils.java
@@ -50,6 +50,7 @@ public class TextureUtils {
             i++;
         }
 
+        GAME.debug(i + " guis textures loaded.");
         ShaderManager.PLAN_SHADERS.setUniform("guiTextures", guiTexturesUnits);
         ShaderManager.ENTITY_SHADER.setUniform("texturesNumber", BLOCKS_TEXTURES + guiTexturesUnits.length);
 
@@ -138,6 +139,7 @@ public class TextureUtils {
 
     private static int createTexture(ByteBuffer image, int width, int height) {
         int textureID = glGenTextures();
+
         glActiveTexture(GL_TEXTURE0 + textureID);
         glBindTexture(GL_TEXTURE_2D, textureID);
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/TextureUtils.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/TextureUtils.java
@@ -34,7 +34,7 @@ public class TextureUtils {
         for (Texture texture : TextureTypes.GUIS.get()) {
 
             int textureID = texture.isBuffered() ?
-                    loadTexture(texture.getBuffer(), texture.getWidth(), texture.getHeight(), texture.getPath()) : loadTexture(texture.getPath());
+                    createTexture(texture.getBuffer(), texture.getWidth(), texture.getHeight()) : loadTexture(texture.getPath());
 
             glActiveTexture(textureID); // Active l'unité de texture correspondante
             glBindTexture(GL_TEXTURE_2D, textureID);
@@ -113,16 +113,20 @@ public class TextureUtils {
         GAME.debug("Done!");
     }
 
-    private static int loadTexture(ByteBuffer image, int width, int height, String path) {
+    private static int loadTexture(String path) {
         int textureID = glGenTextures();
-
         glActiveTexture(GL_TEXTURE0 + textureID);
         glBindTexture(GL_TEXTURE_2D, textureID);
 
         GAME.debug(path + " -> " + textureID );
 
+        IntBuffer width = BufferUtils.createIntBuffer(1);
+        IntBuffer height = BufferUtils.createIntBuffer(1);
+        IntBuffer comp = BufferUtils.createIntBuffer(1);
+        ByteBuffer image = STBImage.stbi_load(path, width, height, comp, 4);
+
         if (image != null) {
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width.get(), height.get(), 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
             glGenerateMipmap(GL_TEXTURE_2D);
             STBImage.stbi_image_free(image);
         } else {
@@ -132,14 +136,15 @@ public class TextureUtils {
         return textureID;
     }
 
-    private static int loadTexture(String path) {
+    private static int createTexture(ByteBuffer image, int width, int height) {
+        int textureID = glGenTextures();
+        glActiveTexture(GL_TEXTURE0 + textureID);
+        glBindTexture(GL_TEXTURE_2D, textureID);
 
-        IntBuffer width = BufferUtils.createIntBuffer(1);
-        IntBuffer height = BufferUtils.createIntBuffer(1);
-        IntBuffer comp = BufferUtils.createIntBuffer(1);
-        ByteBuffer image = STBImage.stbi_load(path, width, height, comp, 4);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
+        glGenerateMipmap(GL_TEXTURE_2D);
 
-        return loadTexture(image, width.get(), height.get(), path);
+        return textureID;
     }
 
     private static int initBlocksTextures() {

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/TextureUtils.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/TextureUtils.java
@@ -32,7 +32,10 @@ public class TextureUtils {
         int[] guiTexturesUnits = new int[TextureTypes.GUIS.get().size()];
         int i=0;
         for (Texture texture : TextureTypes.GUIS.get()) {
-            int textureID = loadTexture(texture.getPath());
+
+            int textureID = texture.isBuffered() ?
+                    loadTexture(texture.getBuffer(), texture.getWidth(), texture.getHeight(), texture.getPath()) : loadTexture(texture.getPath());
+
             glActiveTexture(textureID); // Active l'unité de texture correspondante
             glBindTexture(GL_TEXTURE_2D, textureID);
             glGenerateMipmap(GL_TEXTURE_2D);
@@ -110,20 +113,16 @@ public class TextureUtils {
         GAME.debug("Done!");
     }
 
-    private static int loadTexture(String path) {
+    private static int loadTexture(ByteBuffer image, int width, int height, String path) {
         int textureID = glGenTextures();
+
         glActiveTexture(GL_TEXTURE0 + textureID);
         glBindTexture(GL_TEXTURE_2D, textureID);
 
         GAME.debug(path + " -> " + textureID );
 
-        IntBuffer width = BufferUtils.createIntBuffer(1);
-        IntBuffer height = BufferUtils.createIntBuffer(1);
-        IntBuffer comp = BufferUtils.createIntBuffer(1);
-        ByteBuffer image = STBImage.stbi_load(path, width, height, comp, 4);
-
         if (image != null) {
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width.get(), height.get(), 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
             glGenerateMipmap(GL_TEXTURE_2D);
             STBImage.stbi_image_free(image);
         } else {
@@ -131,6 +130,16 @@ public class TextureUtils {
         }
 
         return textureID;
+    }
+
+    private static int loadTexture(String path) {
+
+        IntBuffer width = BufferUtils.createIntBuffer(1);
+        IntBuffer height = BufferUtils.createIntBuffer(1);
+        IntBuffer comp = BufferUtils.createIntBuffer(1);
+        ByteBuffer image = STBImage.stbi_load(path, width, height, comp, 4);
+
+        return loadTexture(image, width.get(), height.get(), path);
     }
 
     private static int initBlocksTextures() {

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/TextureUtils.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/TextureUtils.java
@@ -145,6 +145,7 @@ public class TextureUtils {
 
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, image);
         glGenerateMipmap(GL_TEXTURE_2D);
+        STBImage.stbi_image_free(image);
 
         return textureID;
     }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/ChunksContainer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/ChunksContainer.java
@@ -166,7 +166,7 @@ public class ChunksContainer {
         light.setToUpdate(true);
 
         // Save synchronously before discarding data so we don't read half-written files
-        fullChunk.unload(false);
+        fullChunk.unload(true);
         registerChunk(key, light);
         return light;
     }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/generators/utils/HeightCalculation.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/generators/utils/HeightCalculation.java
@@ -8,6 +8,8 @@ import fr.rhumun.game.worldcraftopengl.worlds.generators.NormalWorldGenerator;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.biomes.Biome;
 import lombok.Getter;
 
+import static fr.rhumun.game.worldcraftopengl.Game.GAME;
+
 @Getter
 public class HeightCalculation {
 
@@ -67,8 +69,8 @@ public class HeightCalculation {
 
 //        System.out.println(continentalValue + "(" + cH + ") "  + " - " + erosionValue  + "(" + eH + ") = " + base);
 
-        if(base>256) System.out.println(cH + " " + eH + " " + pavEffect + " ( " + continentalValue +" " + pavLargeScale + " )");
+        if(base>worldGenerator.getWorld().getHeigth()) GAME.warn("Generation exceded world height : " + cH + " " + eH + " " + pavEffect + " ( " + continentalValue +" " + pavLargeScale + " )");
 
-        return Math.max(0, Math.min(worldGenerator.getWorld().getHeigth(), base));
+        return Math.max(0, Math.min(worldGenerator.getWorld().getHeigth()-1, base));
     }
 }


### PR DESCRIPTION
## Summary
- introduce a title menu with Play and Quit buttons
- add a GameState enum and manage states
- start world and player loading when Play is pressed
- adjust control logic for game states
- make graphic module ignore world until the game starts

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6840b1aedce483309d718d8c258e92d5