### PR TITLE
Implement Worlds panel

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
@@ -14,6 +14,7 @@ import fr.rhumun.game.worldcraftopengl.outputs.graphic.GraphicModule;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.title_menu.TitleMenuGui;
 import fr.rhumun.game.worldcraftopengl.worlds.World;
 import fr.rhumun.game.worldcraftopengl.worlds.SaveManager;
+import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -108,11 +109,19 @@ public class Game {
     }
 
     public void startGame(){
+        startGame(Seed.random(), "World");
+    }
+
+    public void startGame(Seed seed){
+        startGame(seed, "World");
+    }
+
+    public void startGame(Seed seed, String name){
         this.getGraphicModule().getGuiModule().closeGUI();
 
         this.gameState = GameState.RUNNING;
 
-        this.world = new World();
+        this.world = new World(seed, name);
         this.world.load();
         this.graphicModule.initWorldGraphics();
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/controls/event/KeyEvent.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/controls/event/KeyEvent.java
@@ -4,6 +4,7 @@ import fr.rhumun.game.worldcraftopengl.Game;
 import fr.rhumun.game.worldcraftopengl.entities.Player;
 import fr.rhumun.game.worldcraftopengl.controls.Controls;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.ChatGui;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.worlds_menu.CreateWorldGui;
 import org.lwjgl.glfw.GLFWKeyCallbackI;
 
 import java.util.List;
@@ -27,6 +28,18 @@ public class KeyEvent implements GLFWKeyCallbackI {
             ChatGui chat = game.getGraphicModule().getGuiModule().getChat();
             if(chat.isShowed() && (!Controls.exists(key) || (Controls.get(key) != Controls.ENTER && Controls.get(key) != Controls.ESCAPE))){
                 chat.getEnteredText().print(String.valueOf((char) key));
+                return;
+            }
+
+            if(game.getGraphicModule().getGuiModule().hasGUIOpened() &&
+                    game.getGraphicModule().getGuiModule().getGui() instanceof CreateWorldGui create){
+                if(key == 259){ // backspace
+                    create.backspace();
+                } else if(!Controls.exists(key) || (Controls.get(key) != Controls.ENTER && Controls.get(key) != Controls.ESCAPE)) {
+                    create.appendChar((char) key);
+                } else if(Controls.get(key) == Controls.ENTER){
+                    create.createWorld();
+                }
                 return;
             }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GuiModule.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GuiModule.java
@@ -190,5 +190,9 @@ public class GuiModule {
                 }
             }
         }
+
+        if(this.gui instanceof fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.worlds_menu.CreateWorldGui cw) {
+            cw.handleClick();
+        }
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/InputField.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/InputField.java
@@ -1,0 +1,37 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components;
+
+import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.TextComponent;
+
+/**
+ * Simple clickable text input field using a TextComponent to display entered characters.
+ */
+public class InputField extends Component {
+    private final TextComponent textComponent;
+
+    public InputField(int x, int y, int width, int height, Component container) {
+        super(x, y, width, height, Texture.DEFAULT_BUTTON, container);
+        this.textComponent = new TextComponent(5, 5, "", this);
+        this.addComponent(textComponent);
+    }
+
+    public void append(char c) {
+        textComponent.print(String.valueOf(c));
+    }
+
+    public void backspace() {
+        String txt = textComponent.getText();
+        if (!txt.isEmpty()) {
+            textComponent.setText(txt.substring(0, txt.length() - 1));
+        }
+    }
+
+    public String getText() {
+        return textComponent.getText();
+    }
+
+    @Override
+    public void update() {
+        // Nothing specific
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/title_menu/PlayButton.java
@@ -5,6 +5,7 @@ import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Button;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Gui;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.TextComponent;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.worlds_menu.CreateWorldGui;
 
 import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 
@@ -17,6 +18,6 @@ public class PlayButton extends Button {
 
     @Override
     public void onClick(Player player) {
-        GAME.startGame();
+        player.openGui(new CreateWorldGui());
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/CreateWorldButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/CreateWorldButton.java
@@ -1,0 +1,24 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.worlds_menu;
+
+import fr.rhumun.game.worldcraftopengl.Game;
+import fr.rhumun.game.worldcraftopengl.entities.Player;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Button;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Gui;
+import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
+
+/**
+ * Button used in CreateWorldGui to launch the game with the chosen parameters.
+ */
+public class CreateWorldButton extends Button {
+    private final CreateWorldGui gui;
+
+    public CreateWorldButton(int x, int y, CreateWorldGui gui) {
+        super(x, y, gui, "Create");
+        this.gui = gui;
+    }
+
+    @Override
+    public void onClick(Player player) {
+        gui.createWorld();
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/CreateWorldGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/CreateWorldGui.java
@@ -1,0 +1,63 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.worlds_menu;
+
+import fr.rhumun.game.worldcraftopengl.Game;
+import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.CenteredGUI;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.InputField;
+import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
+
+/**
+ * GUI allowing the user to choose a world name and a seed before starting the game.
+ */
+public class CreateWorldGui extends CenteredGUI {
+    private final InputField nameField;
+    private final InputField seedField;
+    private InputField active;
+
+    public CreateWorldGui() {
+        super(500, 500, Texture.PLANKS);
+
+        this.addText(0, -200, "Create World");
+        this.addText(-200, -100, "Name:");
+        nameField = new InputField(-50, -110, 300, 40, this);
+        this.addComponent(nameField);
+
+        this.addText(-200, -40, "Seed:");
+        seedField = new InputField(-50, -50, 300, 40, this);
+        this.addComponent(seedField);
+
+        this.addButton(new CreateWorldButton(0, 80, this));
+        active = nameField;
+    }
+
+    public void handleClick() {
+        if (nameField.isCursorIn()) active = nameField;
+        else if (seedField.isCursorIn()) active = seedField;
+    }
+
+    public void appendChar(char c) {
+        if (active != null) active.append(c);
+    }
+
+    public void backspace() {
+        if (active != null) active.backspace();
+    }
+
+    public String getWorldName() {
+        return nameField.getText();
+    }
+
+    public Seed getSeed() {
+        String text = seedField.getText();
+        return text.isEmpty() ? Seed.random() : Seed.create(text);
+    }
+
+    public void createWorld() {
+        Game.GAME.startGame(getSeed(), getWorldName());
+    }
+
+    @Override
+    public void update() {
+        // Nothing specific
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/LoadWorldButton.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/LoadWorldButton.java
@@ -1,0 +1,21 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.worlds_menu;
+
+import fr.rhumun.game.worldcraftopengl.Game;
+import fr.rhumun.game.worldcraftopengl.entities.Player;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Button;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Gui;
+import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
+
+public class LoadWorldButton extends Button {
+    private final Seed seed;
+
+    public LoadWorldButton(int x, int y, Seed seed, String name, Gui container) {
+        super(x, y, container, name);
+        this.seed = seed;
+    }
+
+    @Override
+    public void onClick(Player player) {
+        Game.GAME.startGame(seed);
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/WorldsGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/WorldsGui.java
@@ -1,0 +1,14 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.worlds_menu;
+
+import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.CenteredGUI;
+
+public class WorldsGui extends CenteredGUI {
+
+    public WorldsGui() {
+        super(500, 500, Texture.PLANKS);
+
+        this.addText(0, -200, "Worlds");
+        this.addComponent(new WorldsPanel(0, -150, this));
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/WorldsPanel.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/WorldsPanel.java
@@ -1,0 +1,27 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.worlds_menu;
+
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Gui;
+import fr.rhumun.game.worldcraftopengl.worlds.SaveManager;
+import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
+
+import java.util.List;
+
+public class WorldsPanel extends Gui {
+
+    public WorldsPanel(int x, int y, Gui container) {
+        super(x, y, 200, 200, null, container);
+
+        int offset = 0;
+        List<Seed> seeds = SaveManager.listWorldSeeds();
+        for (Seed seed : seeds) {
+            String name = SaveManager.getWorldName(seed);
+            this.addButton(new LoadWorldButton(0, offset, seed, name, this));
+            offset += 50;
+        }
+    }
+
+    @Override
+    public void update() {
+        // Nothing to update
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/World.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/World.java
@@ -23,6 +23,7 @@ public class World {
 
     private final Seed seed;
     private final WorldGenerator generator;
+    private String name;
 
     //private final HashMap<Point, Chunk> chunks = new HashMap<>();
     private final ChunksContainer chunks;
@@ -46,8 +47,17 @@ public class World {
     }
 
     public World(){
+        this(Seed.random(), "World");
+    }
+
+    public World(Seed seed){
+        this(seed, "World");
+    }
+
+    public World(Seed seed, String name){
         //this.seed = Seed.create("1408502280");
-        this.seed = Seed.random();
+        this.seed = seed;
+        this.name = name;
         this.chunks = new ChunksContainer(this);
         this.generator = new NormalWorldGenerator(this);
         //this.generator = new Flat(this);


### PR DESCRIPTION
## Summary
- list available worlds from `SaveManager`
- add constructor to load a world from a seed
- allow `Game.startGame` to take a seed
- implement `LoadWorldButton`, `WorldsPanel`, and `WorldsGui`
- add text fields to world creation for world name and seed

## Testing
- `./mvnw -q -DskipTests package` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6843009b005883309489324f132c4081