### PR TITLE
Display selected item under cursor

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GuiModule.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GuiModule.java
@@ -11,6 +11,7 @@ import fr.rhumun.game.worldcraftopengl.outputs.graphic.utils.FontLoader;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Gui;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.Crossair;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.HotBarGui;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.SelectedItemDisplay;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.utils.ShaderManager;
 import lombok.Getter;
 import lombok.Setter;
@@ -39,6 +40,7 @@ public class GuiModule {
     private final DebugMenu debugMenu;
     private final ChatGui chat;
     private final HotBarGui hotbar;
+    private final SelectedItemDisplay selectedItemDisplay;
     private Gui gui;
     private ItemStack selectedItem;
 
@@ -63,6 +65,7 @@ public class GuiModule {
 
         this.hud.add(new Crossair());
         this.hud.add(this.hotbar = new HotBarGui());
+        this.selectedItemDisplay = new SelectedItemDisplay();
     }
 
     public void init(){
@@ -70,6 +73,8 @@ public class GuiModule {
 
         for(Gui gui : hud)
             gui.init();
+
+        this.selectedItemDisplay.init();
 
 
         if(gui != null)
@@ -116,7 +121,13 @@ public class GuiModule {
                 gui.cleanup();
                 this.gui = null;
 
-            } else gui.render();
+            } else {
+                gui.render();
+                if(selectedItem != null) {
+                    selectedItemDisplay.setItem(selectedItem);
+                    selectedItemDisplay.render();
+                }
+            }
         }else{
             for(Gui gui : hud)
                 gui.render();
@@ -133,6 +144,8 @@ public class GuiModule {
 
         if(gui != null)
             gui.cleanup();
+
+        selectedItemDisplay.cleanup();
     }
 
     public void updateInventory(Player player){

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/SelectedItemDisplay.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/SelectedItemDisplay.java
@@ -1,0 +1,59 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components;
+
+import fr.rhumun.game.worldcraftopengl.content.items.ItemStack;
+import fr.rhumun.game.worldcraftopengl.entities.Player;
+
+import static fr.rhumun.game.worldcraftopengl.Game.GUI_ZOOM;
+
+/**
+ * Component used to display the currently selected item at the cursor
+ * position when a GUI is opened.
+ */
+public class SelectedItemDisplay extends Slot {
+
+    private ItemStack item;
+    private ItemStack displayedItem;
+    private int lastX;
+    private int lastY;
+
+    public SelectedItemDisplay() {
+        super(0, 0, DEFAULT_SIZE, -1, null);
+    }
+
+    @Override
+    public ItemStack getItem() {
+        return item;
+    }
+
+    @Override
+    public void setItem(ItemStack item) {
+        this.item = item;
+    }
+
+    @Override
+    public void update() {
+        int x = (getGuiModule().getCursorX() - getWidth() / 2) / GUI_ZOOM;
+        int y = (getGuiModule().getCursorY() - getHeight() / 2) / GUI_ZOOM;
+        set2DCoordinates(x, y);
+
+        if (item != displayedItem || x != lastX || y != lastY) {
+            if (item == null) {
+                setTexture(null);
+                getText().setText("");
+            } else {
+                setTexture(item.getMaterial().getMaterial().getTexture());
+                if (item.getQuantity() == 1) getText().setText("");
+                else getText().setText(String.valueOf(item.getQuantity()));
+            }
+            updateVertices(item);
+            displayedItem = item;
+            lastX = x;
+            lastY = y;
+        }
+    }
+
+    @Override
+    public void onClick(Player player) {
+        // No action when clicking this component
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Slot.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Slot.java
@@ -61,7 +61,7 @@ public class Slot extends Button {
         this.showedItem = item;
     }
 
-    private void updateVertices(ItemStack item) {
+    protected void updateVertices(ItemStack item) {
         this.getVerticesList().clear();
         this.getIndicesList().clear();
 
@@ -109,7 +109,7 @@ public class Slot extends Button {
         updateVAO();
     }
 
-    private void addVertex(float[] vertexData) {
+    protected void addVertex(float[] vertexData) {
         this.getVerticesList().add(vertexData);
         this.indicesList.add(indicesList.isEmpty() ? 0 : indicesList.getLast()+1);
     }


### PR DESCRIPTION
## Summary
- add `SelectedItemDisplay` component to render selected item at the cursor
- allow `Slot` subclasses to call `updateVertices` and `addVertex`
- integrate the display in `GuiModule` render loop

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685134f5979083309c940077ed12ed59