### PR TITLE
Add simple day-night cycle

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/GameLoop.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/GameLoop.java
@@ -59,6 +59,7 @@ public class GameLoop extends Thread {
                 }
 
                 if(game.getGameState() == GameState.RUNNING) {
+                    player.getWorld().updateTime();
                     Movements.applyMovements(player);
                     player.update();
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/World.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/World.java
@@ -7,6 +7,7 @@ import fr.rhumun.game.worldcraftopengl.worlds.generators.NormalWorldGenerator;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.WorldGenerator;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
 import fr.rhumun.game.worldcraftopengl.worlds.structures.Structure;
+import fr.rhumun.game.worldcraftopengl.worlds.utils.DayNightCycle;
 import javafx.scene.paint.Color;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,6 +22,9 @@ import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 @Getter
 public class World {
 
+    /** Duration of a full day/night cycle in ticks. */
+    public static final int DAY_NIGHT_TICKS = 24000;
+
     private final Seed seed;
     private final WorldGenerator generator;
 
@@ -33,6 +37,8 @@ public class World {
 
     private Color skyColor = Color.rgb(77, 150, 230);
     private Color lightColor = Color.rgb(180, 170, 170);
+
+    private final DayNightCycle dayNightCycle = new DayNightCycle(this);
 
     private final int heigth = 256;
 
@@ -184,5 +190,13 @@ public class World {
 
     public void spawnItem(ItemStack selectedItem, Location location) {
         EntityFactory.createItemEntity(location, selectedItem);
+    }
+
+    public void updateTime() {
+        dayNightCycle.update();
+    }
+
+    public void setSkyColor(Color color) {
+        this.skyColor = color;
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/utils/DayNightCycle.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/utils/DayNightCycle.java
@@ -1,0 +1,60 @@
+package fr.rhumun.game.worldcraftopengl.worlds.utils;
+
+import fr.rhumun.game.worldcraftopengl.worlds.World;
+import javafx.scene.paint.Color;
+
+/**
+ * Utility handling world time and sky color based on a day/night cycle.
+ */
+public class DayNightCycle {
+
+    private final World world;
+    private int tick;
+
+    public DayNightCycle(World world) {
+        this.world = world;
+    }
+
+    /** Update the cycle and world sky color. */
+    public void update() {
+        tick = (tick + 1) % World.DAY_NIGHT_TICKS;
+        world.setSkyColor(computeSkyColor());
+    }
+
+    public int getTick() {
+        return tick;
+    }
+
+    public void setTick(int tick) {
+        this.tick = ((tick % World.DAY_NIGHT_TICKS) + World.DAY_NIGHT_TICKS) % World.DAY_NIGHT_TICKS;
+        world.setSkyColor(computeSkyColor());
+    }
+
+    /**
+     * Convert tick count to an HH:mm formatted time.
+     */
+    public static String tickToTime(int tick) {
+        int minutes = (int) ((long) tick * 24 * 60 / World.DAY_NIGHT_TICKS);
+        int hour = (minutes / 60) % 24;
+        int minute = minutes % 60;
+        return String.format("%02d:%02d", hour, minute);
+    }
+
+    /**
+     * Convert an HH:mm formatted time to ticks.
+     */
+    public static int timeToTick(String time) {
+        String[] parts = time.split(":");
+        int hour = Integer.parseInt(parts[0]);
+        int minute = Integer.parseInt(parts[1]);
+        int total = hour * 60 + minute;
+        return (int) ((long) total * World.DAY_NIGHT_TICKS / (24 * 60));
+    }
+
+    private Color computeSkyColor() {
+        Color day = Color.rgb(77, 150, 230);
+        double progress = (double) tick / World.DAY_NIGHT_TICKS;
+        double t = 0.5 * (1 - Math.cos(progress * 2 * Math.PI));
+        return Color.color(day.getRed() * t, day.getGreen() * t, day.getBlue() * t);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `DayNightCycle` utility
- allow `World` to update its sky color depending on time
- update the game loop to progress world time

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859522c01108330874901dda8f0ead2