### PR TITLE
Implement uniform location caching

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/shaders/Shader.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/shaders/Shader.java
@@ -7,6 +7,8 @@ import org.joml.Vector3f;
 import org.lwjgl.system.MemoryStack;
 
 import java.nio.FloatBuffer;
+import java.util.HashMap;
+import java.util.Map;
 
 import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 import static org.lwjgl.opengl.GL20.*;
@@ -14,15 +16,26 @@ import static org.lwjgl.opengl.GL20.*;
 @Getter
 public abstract class Shader {
     public int id;
+    protected final Map<String, Integer> uniformLocations = new HashMap<>();
 
     public Shader(int id){
         this.id = id;
     }
 
+    protected int getLocation(String uniformName) {
+        Integer cached = uniformLocations.get(uniformName);
+        if (cached == null) {
+            int loc = glGetUniformLocation(id, uniformName);
+            uniformLocations.put(uniformName, loc);
+            return loc;
+        }
+        return cached;
+    }
+
     // Méthode pour envoyer un vecteur 3D (vec3) au shader
     public void setUniform(String uniformName, Vector3f vector) {
         GLStateManager.useProgram(id);
-        int location = glGetUniformLocation(id, uniformName);
+        int location = getLocation(uniformName);
         if (location != -1) {
             glUniform3f(location, vector.x, vector.y, vector.z);
         }
@@ -31,7 +44,7 @@ public abstract class Shader {
     // Méthode pour envoyer un float au shader
     public void setUniform(String uniformName, float value) {
         GLStateManager.useProgram(id);
-        int location = glGetUniformLocation(id, uniformName);
+        int location = getLocation(uniformName);
         if (location != -1) {
             glUniform1f(location, value);
         }
@@ -40,7 +53,7 @@ public abstract class Shader {
     // Méthode pour envoyer un float au shader
     public void setUniform(String uniformName, int value) {
         GLStateManager.useProgram(id);
-        int location = glGetUniformLocation(id, uniformName);
+        int location = getLocation(uniformName);
         if (location != -1) {
             glUniform1i(location, value);
         }
@@ -49,7 +62,7 @@ public abstract class Shader {
     // Méthode pour envoyer un int[] au shader
     public void setUniform(String uniformName, int[] value) {
         GLStateManager.useProgram(id);
-        int location = glGetUniformLocation(id, uniformName);
+        int location = getLocation(uniformName);
         if (location != -1) {
             glUniform1iv(location, value);
         }
@@ -59,7 +72,7 @@ public abstract class Shader {
 
     public void setUniform(String uniformName, float[] value) {
         GLStateManager.useProgram(id);
-        int location = glGetUniformLocation(id, uniformName);
+        int location = getLocation(uniformName);
         if (location != -1) {
             glUniform4fv(location, value);
         }
@@ -67,7 +80,7 @@ public abstract class Shader {
 
     public void setUniformMatrix(String uniformName, float[] value) {
         GLStateManager.useProgram(id);
-        int location = glGetUniformLocation(id, uniformName);
+        int location = getLocation(uniformName);
         if (location != -1) {
             glUniformMatrix4fv(location, false, value);
         }
@@ -75,7 +88,7 @@ public abstract class Shader {
 
     public void setUniform(String name, Matrix4f matrix) {
         GLStateManager.useProgram(id);
-        int location = glGetUniformLocation(id, name);
+        int location = getLocation(name);
         if (location != -1) {
             try (MemoryStack stack = MemoryStack.stackPush()) {
                 FloatBuffer buffer = stack.mallocFloat(16);


### PR DESCRIPTION
## Summary
- store uniform locations in a `Map` inside `Shader`
- use cached locations across all `setUniform` methods

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859c76810748330a6b0824f1de82757