### PR TITLE
Add fluid propagation system

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/GameLoop.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/GameLoop.java
@@ -64,7 +64,6 @@ public class GameLoop extends Thread {
                     player.update();
 
                     player.getWorld().updateEntities(player, 48);
-                    player.getWorld().updateFluids();
                 }
             }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/GameLoop.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/GameLoop.java
@@ -64,6 +64,7 @@ public class GameLoop extends Thread {
                     player.update();
 
                     player.getWorld().updateEntities(player, 48);
+                    player.getWorld().updateFluids();
                 }
             }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/entities/Entity.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/entities/Entity.java
@@ -348,6 +348,9 @@ public class Entity {
 
         model.setBlockDataOnPlace(block, hitPosition, direction);
 
+        if(material.isLiquid())
+            block.setState(8);
+
         if (material instanceof Multiblock multi) {
             multi.onPlace(block);
         }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/entities/Entity.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/entities/Entity.java
@@ -8,6 +8,7 @@ import fr.rhumun.game.worldcraftopengl.content.models.ModelMultiHitbox;
 import fr.rhumun.game.worldcraftopengl.entities.physics.hitbox.Hitbox;
 import fr.rhumun.game.worldcraftopengl.content.items.ItemStack;
 import fr.rhumun.game.worldcraftopengl.worlds.Block;
+import fr.rhumun.game.worldcraftopengl.worlds.utils.fluids.FluidSimulator;
 import fr.rhumun.game.worldcraftopengl.content.Model;
 import fr.rhumun.game.worldcraftopengl.entities.physics.Movements;
 import fr.rhumun.game.worldcraftopengl.entities.physics.hitbox.AxisAlignedBB;
@@ -351,6 +352,9 @@ public class Entity {
         if(material.isLiquid())
             block.setState(8);
 
+        // Propagate fluids once the block is placed
+        FluidSimulator.onBlockUpdate(block);
+
         if (material instanceof Multiblock multi) {
             multi.onPlace(block);
         }
@@ -361,6 +365,7 @@ public class Entity {
         if(block == null || block.getMaterial() == null) return null;
         Material mat = block.getMaterial();
         block.setMaterial(null);
+        FluidSimulator.onBlockUpdate(block);
         return mat;
     }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/models/liquids/LiquidSurfaceUtil.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/utils/models/liquids/LiquidSurfaceUtil.java
@@ -36,7 +36,7 @@ public class LiquidSurfaceUtil {
             if(hasFluidAbove(testBlock)) break;
 
             if (testBlock.getModel() == model) {
-                if (testBlock.getMaterial() == corner1.getMaterial()) {
+                if (testBlock.getMaterial() == corner1.getMaterial() && testBlock.getState() == corner1.getState()) {
 
                     if(isToRender(testBlock, testBlock.getBlockAtNorth()) != hasBlockNorth) break;
                     if(isToRender(testBlock, testBlock.getBlockAtSouth()) != hasBlockSouth) break;
@@ -62,7 +62,7 @@ public class LiquidSurfaceUtil {
 
                 if (!blocks.contains(testBlock)) {
                     if (testBlock.getModel() == model) {
-                        if (testBlock.getMaterial() == corner1.getMaterial()) {
+                        if (testBlock.getMaterial() == corner1.getMaterial() && testBlock.getState() == corner1.getState()) {
                             if (!testBlock.isSurrounded()) {
                                 if(isToRender(testBlock, testBlock.getBlockAtNorth()) != hasBlockNorth) break;
                                 if(isToRender(testBlock, testBlock.getBlockAtSouth()) != hasBlockSouth) break;
@@ -103,12 +103,17 @@ public class LiquidSurfaceUtil {
 
     protected static void rasterBlockGroup(Block corner1, Block corner2, ChunkRenderer chunkRenderer) {
         float x1 = (float) corner1.getLocation().getX() - 0.5f;
-        float y1 = (float) corner1.getLocation().getY() + 1f -0.2f;
+        float y1 = (float) corner1.getLocation().getY() + 1f -0.1f;
         float z1 = (float) corner1.getLocation().getZ() - 0.5f;
 
         float x2 = (float) corner2.getLocation().getX() + 0.5f;
         float y2 = (float) corner2.getLocation().getY();
         float z2 = (float) corner2.getLocation().getZ() + 0.5f;
+
+        float diff = (9-(float)corner1.getState())/10f;
+        y1 = Math.max(y1-diff, 0f);
+
+        System.out.println(diff);
 
         boolean showNorth = isToRender(corner1, corner1.getBlockAtNorth());
         boolean showSouth = isToRender(corner1, corner1.getBlockAtSouth());

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/World.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/World.java
@@ -8,6 +8,7 @@ import fr.rhumun.game.worldcraftopengl.worlds.generators.WorldGenerator;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
 import fr.rhumun.game.worldcraftopengl.worlds.structures.Structure;
 import fr.rhumun.game.worldcraftopengl.worlds.utils.DayNightCycle;
+import fr.rhumun.game.worldcraftopengl.worlds.utils.fluids.FluidSimulator;
 import javafx.scene.paint.Color;
 import lombok.Getter;
 import lombok.Setter;
@@ -196,6 +197,11 @@ public class World {
 
     public LightChunk getLightChunk(int x, int z, boolean b) {
         return this.chunks.getLightChunkAt(x, z);
+    }
+
+    /** Update fluids for all currently loaded chunks. */
+    public void updateFluids() {
+        FluidSimulator.tick(GAME.getGraphicModule().getLoadedChunks());
     }
 
     public void save() {

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/World.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/World.java
@@ -8,7 +8,6 @@ import fr.rhumun.game.worldcraftopengl.worlds.generators.WorldGenerator;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
 import fr.rhumun.game.worldcraftopengl.worlds.structures.Structure;
 import fr.rhumun.game.worldcraftopengl.worlds.utils.DayNightCycle;
-import fr.rhumun.game.worldcraftopengl.worlds.utils.fluids.FluidSimulator;
 import javafx.scene.paint.Color;
 import lombok.Getter;
 import lombok.Setter;
@@ -199,10 +198,6 @@ public class World {
         return this.chunks.getLightChunkAt(x, z);
     }
 
-    /** Update fluids for all currently loaded chunks. */
-    public void updateFluids() {
-        FluidSimulator.tick(GAME.getGraphicModule().getLoadedChunks());
-    }
 
     public void save() {
         for(Chunk chunk : GAME.getGraphicModule().getLoadedChunks())

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/generators/NormalWorldGenerator.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/generators/NormalWorldGenerator.java
@@ -175,6 +175,7 @@ public class NormalWorldGenerator extends WorldGenerator {
                     Block block = chunk.getBlockNoVerif(x, y, z);
                     if (block.getMaterial() != null) continue;
                     block.setMaterial(Materials.WATER);
+                    block.setState(8);
                 }
     }
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/utils/fluids/FluidSimulator.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/utils/fluids/FluidSimulator.java
@@ -1,0 +1,67 @@
+package fr.rhumun.game.worldcraftopengl.worlds.utils.fluids;
+
+import fr.rhumun.game.worldcraftopengl.worlds.Block;
+import fr.rhumun.game.worldcraftopengl.worlds.Chunk;
+import fr.rhumun.game.worldcraftopengl.content.materials.Material;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Simple fluid propagation simulator. Fluid blocks with a state value represent
+ * their remaining strength. Sources have a state of 8 and propagate to
+ * neighbours with decreasing state values until 0.
+ */
+public class FluidSimulator {
+
+    private record FluidUpdate(Block block, Material material, byte state) {}
+
+    public static void tick(Set<Chunk> chunks) {
+        Map<Block, FluidUpdate> updates = new HashMap<>();
+
+        for (Chunk chunk : chunks) {
+            Block[][][] blocks = chunk.getBlocks();
+            int height = chunk.getWorld().getHeigth();
+            for (int x = 0; x < blocks.length; x++) {
+                for (int y = 0; y < height; y++) {
+                    for (int z = 0; z < blocks[x][y].length; z++) {
+                        Block block = blocks[x][y][z];
+                        Material mat = block.getMaterial();
+                        if (mat == null || !mat.isLiquid()) continue;
+
+                        byte level = block.getState();
+                        if (level <= 0) continue;
+
+                        Block down = block.getBlockAtDown();
+                        if (down != null && (down.getMaterial() == null || (down.getMaterial().isLiquid() && down.getState() < 8))) {
+                            updates.put(down, new FluidUpdate(down, mat, (byte) 8));
+                            continue;
+                        }
+
+                        if (level > 1) {
+                            byte next = (byte) (level - 1);
+                            spread(block.getBlockAtNorth(), mat, next, updates);
+                            spread(block.getBlockAtSouth(), mat, next, updates);
+                            spread(block.getBlockAtEast(), mat, next, updates);
+                            spread(block.getBlockAtWest(), mat, next, updates);
+                        }
+                    }
+                }
+            }
+        }
+
+        for (FluidUpdate u : updates.values()) {
+            u.block.setMaterial(u.material);
+            u.block.setState(u.state);
+        }
+    }
+
+    private static void spread(Block target, Material material, byte state, Map<Block, FluidUpdate> updates) {
+        if (target == null) return;
+        Material targetMat = target.getMaterial();
+        if (targetMat == null || (targetMat.isLiquid() && target.getState() < state)) {
+            updates.put(target, new FluidUpdate(target, material, state));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `FluidSimulator` to spread liquid blocks
- call `World.updateFluids` from `GameLoop`
- set fluid state when placing blocks and during world generation

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685a769b05008330a5d1513d9137ec8a