### PR TITLE
Fix NPE when rendering unloaded blocks

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/ChunkRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/ChunkRenderer.java
@@ -159,6 +159,8 @@ public class ChunkRenderer extends AbstractChunkRenderer{
 
                     Block block = chunk.getBlocks()[X][Y][Z];
                     if (block == null || block.getMaterial() == null) continue;
+                    // Skip blocks whose parent chunk was already unloaded
+                    if (block.getChunk() == null) continue;
 
                     Model model = block.getModel();
                     if (model == null) continue;


### PR DESCRIPTION
## Summary
- guard against unloaded blocks in `ChunkRenderer.updateData`

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685adf16e50883309e9857fcba5e6f35