### PR TITLE
Add scroll support to worlds menu

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/controls/Scroll.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/controls/Scroll.java
@@ -1,6 +1,8 @@
 package fr.rhumun.game.worldcraftopengl.controls;
 
 import fr.rhumun.game.worldcraftopengl.Game;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.GuiModule;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.ScrollableGui;
 import org.lwjgl.glfw.GLFWScrollCallback;
 
 import static fr.rhumun.game.worldcraftopengl.Game.GAME;
@@ -15,6 +17,12 @@ public class Scroll extends GLFWScrollCallback {
 
     @Override
     public void invoke(long window, double xoffset, double yoffset) {
+        GuiModule guiModule = game.getGraphicModule().getGuiModule();
+        if (guiModule.hasGUIOpened() && guiModule.getGui() instanceof ScrollableGui sg) {
+            sg.onScroll(yoffset);
+            return;
+        }
+
         if(game.isPaused()) return;
 
         if (yoffset > 0) {

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/ScrollableGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/ScrollableGui.java
@@ -1,0 +1,12 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components;
+
+/**
+ * GUI that reacts to mouse wheel scrolling.
+ */
+public interface ScrollableGui {
+    /**
+     * Called when the mouse wheel is scrolled while this GUI is open.
+     * @param yoffset amount of wheel movement (positive for up, negative for down)
+     */
+    void onScroll(double yoffset);
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/WorldsGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/WorldsGui.java
@@ -2,12 +2,19 @@ package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.worlds_menu;
 
 import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.FullscreenTiledGui;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.ScrollableGui;
 import fr.rhumun.game.worldcraftopengl.worlds.SaveManager;
 import fr.rhumun.game.worldcraftopengl.worlds.WorldInfo;
 
+import java.util.ArrayList;
 import java.util.List;
 
-public class WorldsGui extends FullscreenTiledGui {
+public class WorldsGui extends FullscreenTiledGui implements ScrollableGui {
+
+    private final List<LoadWorldButton> worldButtons = new ArrayList<>();
+    private final CreateWorldButton createButton;
+    private final BackButton backButton;
+    private int scrollOffset = 0;
 
     public WorldsGui() {
         super(Texture.DARK_COBBLE);
@@ -17,14 +24,35 @@ public class WorldsGui extends FullscreenTiledGui {
         int y = -100;
         List<WorldInfo> infos = SaveManager.listWorldInfos();
         for (WorldInfo info : infos) {
-            this.addButton(new LoadWorldButton(0, y, this, info));
+            LoadWorldButton btn = new LoadWorldButton(0, y, this, info);
+            this.addButton(btn);
+            worldButtons.add(btn);
             y += 50;
         }
 
-        this.addButton(new CreateWorldButton(0, y, this));
+        createButton = new CreateWorldButton(0, y, this);
+        this.addButton(createButton);
         y += 60;
-        this.addButton(new BackButton(0, y, this));
+        backButton = new BackButton(0, y, this);
+        this.addButton(backButton);
 
         this.setAlignCenter(true);
+    }
+
+    @Override
+    public void onScroll(double yoffset) {
+        scrollOffset += yoffset > 0 ? 20 : -20;
+        updatePositions();
+    }
+
+    private void updatePositions() {
+        int y = -100 + scrollOffset;
+        for (LoadWorldButton btn : worldButtons) {
+            setCoordinates(btn, 0, y);
+            y += 50;
+        }
+        setCoordinates(createButton, 0, y);
+        y += 60;
+        setCoordinates(backButton, 0, y);
     }
 }


### PR DESCRIPTION
## Summary
- make the mouse scroll callback delegate to GUIs if they implement `ScrollableGui`
- add a `ScrollableGui` interface
- implement scrolling in `WorldsGui` to allow the world list to be moved with the mouse wheel

## Testing
- `mvn -q -DskipTests=true package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb28d61748330954224b21f79164e