### PR TITLE
Implement bucket interaction with water

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/materials/Material.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/materials/Material.java
@@ -1,6 +1,7 @@
 package fr.rhumun.game.worldcraftopengl.content.materials;
 
 import fr.rhumun.game.worldcraftopengl.content.GuiTypes;
+import fr.rhumun.game.worldcraftopengl.content.materials.blocks.types.FluidMaterial;
 import fr.rhumun.game.worldcraftopengl.content.materials.opacity.OpacityType;
 import fr.rhumun.game.worldcraftopengl.content.materials.blocks.types.PlaceableMaterial;
 import fr.rhumun.game.worldcraftopengl.content.materials.blocks.types.ToolType;
@@ -110,7 +111,7 @@ public abstract class Material {
 
     public Texture getTexture() {return textures[0];}
     public OpacityType getOpacity(){ return this instanceof PlaceableMaterial pM ? pM.getOpacity() : OpacityType.OPAQUE; }
-    public boolean isLiquid() { return this instanceof PlaceableMaterial pM && pM.getOpacity() == OpacityType.LIQUID; }
+    public boolean isLiquid() { return this instanceof FluidMaterial; }
 
     protected void addToType(GuiTypes type){
         type.add(this);

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/materials/Materials.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/materials/Materials.java
@@ -5,7 +5,7 @@ import fr.rhumun.game.worldcraftopengl.content.materials.items.types.BlockItemMa
 import fr.rhumun.game.worldcraftopengl.content.materials.items.types.FoodMaterial;
 import fr.rhumun.game.worldcraftopengl.content.materials.items.types.ItemMaterial;
 import fr.rhumun.game.worldcraftopengl.content.materials.items.types.ToolItemMaterial;
-import fr.rhumun.game.worldcraftopengl.content.materials.items.types.BucketItemMaterial;
+import fr.rhumun.game.worldcraftopengl.content.materials.items.BucketItemMaterial;
 import fr.rhumun.game.worldcraftopengl.content.materials.blocks.types.ToolType;
 import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/materials/items/BucketItemMaterial.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/materials/items/BucketItemMaterial.java
@@ -1,7 +1,9 @@
-package fr.rhumun.game.worldcraftopengl.content.materials.items.types;
+package fr.rhumun.game.worldcraftopengl.content.materials.items;
 
 import fr.rhumun.game.worldcraftopengl.content.items.ItemStack;
 import fr.rhumun.game.worldcraftopengl.content.materials.Materials;
+import fr.rhumun.game.worldcraftopengl.content.materials.items.types.ItemMaterial;
+import fr.rhumun.game.worldcraftopengl.content.materials.items.types.UsableItem;
 import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
 import fr.rhumun.game.worldcraftopengl.entities.player.Player;
 import fr.rhumun.game.worldcraftopengl.worlds.Block;
@@ -16,29 +18,17 @@ public class BucketItemMaterial extends ItemMaterial implements UsableItem {
 
     @Override
     public void onClick(Player player) {
-        final float STEP = 0.02f;
-        Vector3f direction = player.getRayDirection();
-        Vector3f pos = new Vector3f(
-                (float) player.getLocation().getX(),
-                (float) player.getLocation().getY(),
-                (float) player.getLocation().getZ());
 
-        Block target = null;
-        for (float dist = 0; dist < player.getReach(); dist += STEP) {
-            target = player.getWorld().getBlockAt(pos, true);
-            if (target != null && target.getMaterial() != null) {
-                break;
-            }
-            pos.add(direction.x * STEP,
-                    direction.y * STEP,
-                    direction.z * STEP);
-        }
+        Block target = player.getSelectedBlock(false);
 
         if (target != null &&
                 target.getMaterial() == Materials.WATER &&
                 target.getState() == 8) {
             target.setMaterial(null);
+            target.setState(0);
             FluidSimulator.onBlockUpdate(target);
+
+            if(player.isInCreativeMode()) return;
             player.getInventory().setItem(player.getSelectedSlot(),
                     new ItemStack(Materials.WATER_BUCKET));
             player.updateInventory();

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/entities/Entity.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/entities/Entity.java
@@ -296,15 +296,16 @@ public class Entity {
             this.getVelocity().add(0, (float)jumpForce/9, 0);
     }
 
+    public Block getSelectedBlock(){ return getSelectedBlock(true); }
 
-    public Block getSelectedBlock() {
+    public Block getSelectedBlock(boolean ignoreLiquids) {
         Vector3f direction = getRayDirection();
         Vector3f pos = new Vector3f((float) this.getLocation().getX(), (float) this.getLocation().getY(), (float) this.getLocation().getZ());
 
         for (float distance = 0; distance < this.getReach(); distance += RAY_STEP) {
             Block block = GAME.getWorld().getBlockAt(pos, true);
 
-            if (block != null && block.getMaterial() != null && !block.getMaterial().isLiquid()) {
+            if (block != null && block.getMaterial() != null && (!ignoreLiquids || !block.getMaterial().isLiquid())) {
                 return block;
             }
 


### PR DESCRIPTION
## Summary
- add `BucketItemMaterial` for bucket interactions
- register bucket as a usable item in `Materials`
- enable collecting water when clicking full water blocks

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685bc3fabd308330b695fd4a0f428b6f