### PR TITLE
Add world type and gamemode selection

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/Game.java
@@ -14,7 +14,9 @@ import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.LoadingGui;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.title_menu.TitleMenuGui;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.renderers.ChunkRenderer;
 import fr.rhumun.game.worldcraftopengl.worlds.World;
+import fr.rhumun.game.worldcraftopengl.worlds.WorldType;
 import fr.rhumun.game.worldcraftopengl.worlds.SaveManager;
+import fr.rhumun.game.worldcraftopengl.entities.player.Gamemode;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
 import lombok.Getter;
 import lombok.Setter;
@@ -114,29 +116,35 @@ public class Game {
     }
 
     public void startGame(){
-        startGame("My World", Seed.random());
+        startGame("My World", Seed.random(), WorldType.NORMAL, Gamemode.SURVIVAL);
     }
 
     public void startGame(Seed seed){
-        startGame("My World", seed);
+        startGame("My World", seed, WorldType.NORMAL, Gamemode.SURVIVAL);
     }
 
     public void startGame(String name, Seed seed){
+        startGame(name, seed, WorldType.NORMAL, Gamemode.SURVIVAL);
+    }
+
+    public void startGame(String name, Seed seed, WorldType type, Gamemode gamemode){
         var guiModule = this.getGraphicModule().getGuiModule();
         LoadingGui loadingGui = new LoadingGui("Chargement...");
         guiModule.openGUI(loadingGui);
 
         player.reset();
+        player.setGamemode(gamemode);
 
         new Thread(() -> {
-            if(name == null) world = new World(seed);
-            else world = new World(seed, name);
+            if(name == null) world = new World(seed, null, type);
+            else world = new World(seed, name, type);
             world.load();
             while(!world.isLoaded()) Thread.onSpinWait();
 
             boolean first = !SaveManager.loadPlayer(world, player);
             if(first) {
                 world.spawnPlayer(player);
+                player.setGamemode(gamemode);
                 player.addItem(new ItemStack(Materials.WOODEN_PICKAXE));
                 player.addItem(new ItemStack(Materials.SAWMILL));
                 player.addItem(new ItemStack(Materials.PLANKS, Model.STAIRS));

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/textures/Texture.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/textures/Texture.java
@@ -148,6 +148,10 @@ public class Texture {
     public static Texture PLAYER_INVENTORY;
     public static Texture WORKBENCH;
     public static Texture WORKBENCH_2;
+    public static Texture CHECKBOX;
+    public static Texture CHECKBOX_HIGHLIGHTED;
+    public static Texture CHECKBOX_SELECTED;
+    public static Texture CHECKBOX_SELECTED_HIGHLIGHTED;
     public static Texture SQUARE_BUTTON;
     public static Texture DEFAULT_BUTTON;
     public static Texture DEFAULT_BUTTON_HOVERED;
@@ -355,6 +359,10 @@ public class Texture {
         PLAYER_INVENTORY = new Texture(TextureTypes.GUIS,"hud\\player_inventory.png");
         WORKBENCH = new Texture(TextureTypes.GUIS,"hud\\workbench.png");
         WORKBENCH_2 = new Texture(TextureTypes.GUIS,"hud\\workbench_2.png");
+        CHECKBOX = new Texture(TextureTypes.GUIS, "hud\\widgets\\checkbox.png");
+        CHECKBOX_HIGHLIGHTED = new Texture(TextureTypes.GUIS, "hud\\widgets\\checkbox_highlighted.png");
+        CHECKBOX_SELECTED = new Texture(TextureTypes.GUIS, "hud\\widgets\\checkbox_selected.png");
+        CHECKBOX_SELECTED_HIGHLIGHTED = new Texture(TextureTypes.GUIS, "hud\\widgets\\checkbox_selected_highlighted.png");
         SQUARE_BUTTON = new Texture(TextureTypes.GUIS,"hud\\widgets\\checkbox.png");
         DEFAULT_BUTTON = new Texture(TextureTypes.GUIS, "hud\\widgets\\button.png");
         DEFAULT_BUTTON_HOVERED = new Texture(TextureTypes.GUIS, "hud\\widgets\\hovered.png");

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Checkbox.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Checkbox.java
@@ -1,0 +1,67 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components;
+
+import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
+import fr.rhumun.game.worldcraftopengl.entities.player.Player;
+
+/**
+ * Simple checkbox component with a label.
+ */
+public class Checkbox extends Button {
+
+    private boolean checked;
+    private final Texture unchecked;
+    private final Texture uncheckedHover;
+    private final Texture checkedTex;
+    private final Texture checkedHover;
+
+    private Runnable onChange;
+
+    public Checkbox(int x, int y, String label, Gui container) {
+        super(x, y, 150, 32, Texture.CHECKBOX, Texture.CHECKBOX_HIGHLIGHTED,
+                Texture.CHECKBOX, container);
+        this.unchecked = Texture.CHECKBOX;
+        this.uncheckedHover = Texture.CHECKBOX_HIGHLIGHTED;
+        this.checkedTex = Texture.CHECKBOX_SELECTED;
+        this.checkedHover = Texture.CHECKBOX_SELECTED_HIGHLIGHTED;
+
+        this.getText().setText(label);
+        this.getText().set2DCoordinates(40, 8);
+        this.setAlignCenter(false);
+    }
+
+    public void setChecked(boolean checked) {
+        this.checked = checked;
+    }
+
+    public boolean isChecked() {
+        return checked;
+    }
+
+    public void setOnChange(Runnable onChange) {
+        this.onChange = onChange;
+    }
+
+    @Override
+    public void onClick(Player player) {
+        checked = !checked;
+        if (onChange != null) onChange.run();
+    }
+
+    @Override
+    public void update() {
+        if (!isActive()) {
+            set2DTexture(unchecked);
+            return;
+        }
+
+        boolean hover = this.isCursorIn();
+        Texture tex;
+        if (checked) {
+            tex = hover ? checkedHover : checkedTex;
+        } else {
+            tex = hover ? uncheckedHover : unchecked;
+        }
+        set2DTexture(tex);
+    }
+}
+

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Checkbox.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Checkbox.java
@@ -2,22 +2,27 @@ package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components;
 
 import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
 import fr.rhumun.game.worldcraftopengl.entities.player.Player;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Simple checkbox component with a label.
  */
 public class Checkbox extends Button {
 
+    @Getter
+    @Setter
     private boolean checked;
     private final Texture unchecked;
     private final Texture uncheckedHover;
     private final Texture checkedTex;
     private final Texture checkedHover;
 
+    @Setter
     private Runnable onChange;
 
     public Checkbox(int x, int y, String label, Gui container) {
-        super(x, y, 150, 32, Texture.CHECKBOX, Texture.CHECKBOX_HIGHLIGHTED,
+        super(x, y, 32, 32, Texture.CHECKBOX, Texture.CHECKBOX_HIGHLIGHTED,
                 Texture.CHECKBOX, container);
         this.unchecked = Texture.CHECKBOX;
         this.uncheckedHover = Texture.CHECKBOX_HIGHLIGHTED;
@@ -25,20 +30,8 @@ public class Checkbox extends Button {
         this.checkedHover = Texture.CHECKBOX_SELECTED_HIGHLIGHTED;
 
         this.getText().setText(label);
-        this.getText().set2DCoordinates(40, 8);
-        this.setAlignCenter(false);
-    }
-
-    public void setChecked(boolean checked) {
-        this.checked = checked;
-    }
-
-    public boolean isChecked() {
-        return checked;
-    }
-
-    public void setOnChange(Runnable onChange) {
-        this.onChange = onChange;
+        this.getText().set2DCoordinates(-40, 0);
+        this.setAlignCenter(true);
     }
 
     @Override

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/CreateWorldGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/CreateWorldGui.java
@@ -16,16 +16,14 @@ import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 public class CreateWorldGui extends FullscreenTiledGui implements TypingGui {
     private final InputField nameField;
     private final InputField seedField;
-    private final Checkbox normalType;
     private final Checkbox flatType;
-    private final Checkbox survival;
     private final Checkbox creative;
     private InputField activeField;
 
     public CreateWorldGui() {
         super(Texture.DARK_COBBLE);
 
-        this.addText(0, -120, "Créer un Monde");
+        this.addText(0, -150, "Creer un Monde");
         this.addText(-200, -60, "Nom:");
         nameField = new InputField(100, -60, 300, this);
         nameField.setValue("Mon monde");
@@ -38,37 +36,15 @@ public class CreateWorldGui extends FullscreenTiledGui implements TypingGui {
         this.addButton(seedField);
         activeField = nameField;
 
-        this.addText(-200, 40, "Type:");
-        normalType = new Checkbox(100, 40, "Normal", this);
-        flatType = new Checkbox(260, 40, "Flat", this);
-        normalType.setChecked(true);
-        normalType.setOnChange(() -> {
-            normalType.setChecked(true);
-            flatType.setChecked(false);
-        });
-        flatType.setOnChange(() -> {
-            flatType.setChecked(true);
-            normalType.setChecked(false);
-        });
-        this.addButton(normalType);
+        this.addText(-200, 40, "Monde plat:");
+        flatType = new Checkbox(100, 40, "Flat", this);
         this.addButton(flatType);
 
-        this.addText(-200, 90, "Gamemode:");
-        survival = new Checkbox(100, 90, "Survie", this);
-        creative = new Checkbox(260, 90, "Créatif", this);
-        survival.setChecked(true);
-        survival.setOnChange(() -> {
-            survival.setChecked(true);
-            creative.setChecked(false);
-        });
-        creative.setOnChange(() -> {
-            creative.setChecked(true);
-            survival.setChecked(false);
-        });
-        this.addButton(survival);
+        this.addText(-200, 90, "Gamemode Creatif:");
+        creative = new Checkbox(100, 90, "Creatif", this);
         this.addButton(creative);
 
-        this.addButton(new Button(0, 140, this, "Creer le monde") {
+        this.addButton(new Button(110, 180, this, "Creer le monde") {
             @Override
             public void onClick(Player player) {
                 String seedText = seedField.getValue();
@@ -80,7 +56,8 @@ public class CreateWorldGui extends FullscreenTiledGui implements TypingGui {
                 GAME.startGame(name, seed, type, gm);
             }
         });
-        this.addButton(new Button(0, 190, this, "Retour") {
+
+        this.addButton(new Button(-110, 180, this, "Retour") {
             @Override
             public void onClick(Player player) {
                 GAME.getGraphicModule().getGuiModule().openGUI(new WorldsGui());

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/CreateWorldGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/worlds_menu/CreateWorldGui.java
@@ -4,8 +4,11 @@ import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
 import fr.rhumun.game.worldcraftopengl.entities.player.Player;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.FullscreenTiledGui;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Button;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Checkbox;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.InputField;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.TypingGui;
+import fr.rhumun.game.worldcraftopengl.entities.player.Gamemode;
+import fr.rhumun.game.worldcraftopengl.worlds.WorldType;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
 
 import static fr.rhumun.game.worldcraftopengl.Game.GAME;
@@ -13,6 +16,10 @@ import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 public class CreateWorldGui extends FullscreenTiledGui implements TypingGui {
     private final InputField nameField;
     private final InputField seedField;
+    private final Checkbox normalType;
+    private final Checkbox flatType;
+    private final Checkbox survival;
+    private final Checkbox creative;
     private InputField activeField;
 
     public CreateWorldGui() {
@@ -31,17 +38,49 @@ public class CreateWorldGui extends FullscreenTiledGui implements TypingGui {
         this.addButton(seedField);
         activeField = nameField;
 
-        this.addButton(new Button(0, 60, this, "Creer le monde") {
+        this.addText(-200, 40, "Type:");
+        normalType = new Checkbox(100, 40, "Normal", this);
+        flatType = new Checkbox(260, 40, "Flat", this);
+        normalType.setChecked(true);
+        normalType.setOnChange(() -> {
+            normalType.setChecked(true);
+            flatType.setChecked(false);
+        });
+        flatType.setOnChange(() -> {
+            flatType.setChecked(true);
+            normalType.setChecked(false);
+        });
+        this.addButton(normalType);
+        this.addButton(flatType);
+
+        this.addText(-200, 90, "Gamemode:");
+        survival = new Checkbox(100, 90, "Survie", this);
+        creative = new Checkbox(260, 90, "Créatif", this);
+        survival.setChecked(true);
+        survival.setOnChange(() -> {
+            survival.setChecked(true);
+            creative.setChecked(false);
+        });
+        creative.setOnChange(() -> {
+            creative.setChecked(true);
+            survival.setChecked(false);
+        });
+        this.addButton(survival);
+        this.addButton(creative);
+
+        this.addButton(new Button(0, 140, this, "Creer le monde") {
             @Override
             public void onClick(Player player) {
                 String seedText = seedField.getValue();
                 Seed seed = seedText == null || seedText.isEmpty() ? Seed.random() : Seed.create(seedText);
                 String name = nameField.getValue();
                 if (name == null || name.isEmpty()) name = "Mon monde";
-                GAME.startGame(name, seed);
+                WorldType type = flatType.isChecked() ? WorldType.FLAT : WorldType.NORMAL;
+                Gamemode gm = creative.isChecked() ? Gamemode.CREATIVE : Gamemode.SURVIVAL;
+                GAME.startGame(name, seed, type, gm);
             }
         });
-        this.addButton(new Button(0, 110, this, "Retour") {
+        this.addButton(new Button(0, 190, this, "Retour") {
             @Override
             public void onClick(Player player) {
                 GAME.getGraphicModule().getGuiModule().openGUI(new WorldsGui());

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/SaveManager.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/SaveManager.java
@@ -13,6 +13,7 @@ import fr.rhumun.game.worldcraftopengl.worlds.Block;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.biomes.Biome;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.biomes.Biomes;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
+import fr.rhumun.game.worldcraftopengl.worlds.WorldType;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -164,6 +165,7 @@ public class SaveManager {
             out.writeInt(world.getXSpawn());
             out.writeInt(world.getZSpawn());
             out.writeUTF(world.getName() == null ? "" : world.getName());
+            out.writeByte(world.getWorldType().ordinal());
         } catch (IOException e) {
             Game.GAME.errorLog(e);
         }
@@ -182,6 +184,14 @@ public class SaveManager {
                 world.setName(in.readUTF());
             } catch (IOException ignored) {
                 world.setName("World " + world.getSeed().getLong());
+            }
+            try {
+                byte type = in.readByte();
+                if (type >= 0 && type < WorldType.values().length) {
+                    world.setWorldType(WorldType.values()[type]);
+                }
+            } catch (IOException ignored) {
+                world.setWorldType(WorldType.NORMAL);
             }
         } catch (IOException e) {
             Game.GAME.errorLog(e);

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/World.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/World.java
@@ -4,7 +4,9 @@ import fr.rhumun.game.worldcraftopengl.content.items.ItemStack;
 import fr.rhumun.game.worldcraftopengl.entities.*;
 import fr.rhumun.game.worldcraftopengl.entities.player.Player;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.NormalWorldGenerator;
+import fr.rhumun.game.worldcraftopengl.worlds.generators.Flat;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.WorldGenerator;
+import fr.rhumun.game.worldcraftopengl.worlds.WorldType;
 import fr.rhumun.game.worldcraftopengl.worlds.generators.utils.Seed;
 import fr.rhumun.game.worldcraftopengl.worlds.structures.Structure;
 import fr.rhumun.game.worldcraftopengl.worlds.utils.DayNightCycle;
@@ -26,7 +28,9 @@ public class World {
     public static final int DAY_NIGHT_TICKS = 24000;
 
     private final Seed seed;
-    private final WorldGenerator generator;
+    private WorldGenerator generator;
+    @Setter
+    private WorldType worldType = WorldType.NORMAL;
 
     @Setter
     private String name;
@@ -87,18 +91,23 @@ public class World {
     }
 
     public World(){
-        this(Seed.random());
+        this(Seed.random(), null, WorldType.NORMAL);
     }
 
     public World(Seed seed){
-        this(seed, null);
+        this(seed, null, WorldType.NORMAL);
     }
 
     public World(Seed seed, String name){
+        this(seed, name, WorldType.NORMAL);
+    }
+
+    public World(Seed seed, String name, WorldType type){
         this.seed = seed;
         this.name = name;
+        this.worldType = type;
         this.chunks = new ChunksContainer(this);
-        this.generator = new NormalWorldGenerator(this);
+        setGeneratorFromType();
 
         GAME.log("Creating a new World... \nSeed: " + seed.getLong());
 
@@ -106,9 +115,15 @@ public class World {
         zSpawn = seed.getCombinaisonOf(5, 4, 9) * seed.get(1);
     }
 
+    private void setGeneratorFromType() {
+        if (worldType == WorldType.FLAT) this.generator = new Flat(this);
+        else this.generator = new NormalWorldGenerator(this);
+    }
+
     public void load(){
         if(SaveManager.worldExists(this.seed)) {
             SaveManager.loadWorldMeta(this);
+            setGeneratorFromType();
         } else {
             SaveManager.saveWorldMeta(this);
         }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/WorldType.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/worlds/WorldType.java
@@ -1,0 +1,10 @@
+package fr.rhumun.game.worldcraftopengl.worlds;
+
+/**
+ * Enumeration of available world generation types.
+ */
+public enum WorldType {
+    NORMAL,
+    FLAT
+}
+


### PR DESCRIPTION
## Summary
- implement `Checkbox` component for GUIs
- let users choose world type and default gamemode when creating a world
- persist world type in save data
- support world type and gamemode in `Game.startGame`

## Testing
- `./mvnw -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685bd91b1c2483308315b6034f48b3b2