### PR TITLE
Add more crafting recipes

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/workbench/Sawmill.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/workbench/Sawmill.java
@@ -28,5 +28,36 @@ public class Sawmill extends Workbench {
         this.addResults(new ItemStack(Materials.BIRCH_PLANKS), new ItemStack[]{
                 new ItemStack(Materials.BIRCH_PLANKS, Model.SLAB, 2),
                 new ItemStack(Materials.BIRCH_PLANKS, Model.CYLINDER, 1) });
+
+        this.addResults(new ItemStack(Materials.ACACIA_LOG), new ItemStack[]{
+                new ItemStack(Materials.ACACIA_PLANKS, Model.BLOCK, 4),
+                new ItemStack(Materials.ACACIA_PLANKS, Model.SLAB, 8),
+                new ItemStack(Materials.ACACIA_PLANKS, Model.CYLINDER, 4) });
+
+        this.addResults(new ItemStack(Materials.ACACIA_PLANKS), new ItemStack[]{
+                new ItemStack(Materials.ACACIA_PLANKS, Model.SLAB, 2),
+                new ItemStack(Materials.ACACIA_PLANKS, Model.CYLINDER, 1) });
+
+        this.addResults(new ItemStack(Materials.CHERRY_LOG), new ItemStack[]{
+                new ItemStack(Materials.CHERRY_PLANKS, Model.BLOCK, 4),
+                new ItemStack(Materials.CHERRY_PLANKS, Model.SLAB, 8),
+                new ItemStack(Materials.CHERRY_PLANKS, Model.CYLINDER, 4) });
+
+        this.addResults(new ItemStack(Materials.CHERRY_PLANKS), new ItemStack[]{
+                new ItemStack(Materials.CHERRY_PLANKS, Model.SLAB, 2),
+                new ItemStack(Materials.CHERRY_PLANKS, Model.CYLINDER, 1) });
+
+        this.addResults(new ItemStack(Materials.SPRUCE_LOG), new ItemStack[]{
+                new ItemStack(Materials.SPRUCE_PLANKS, Model.BLOCK, 4),
+                new ItemStack(Materials.SPRUCE_PLANKS, Model.SLAB, 8),
+                new ItemStack(Materials.SPRUCE_PLANKS, Model.CYLINDER, 4) });
+
+        this.addResults(new ItemStack(Materials.SPRUCE_PLANKS), new ItemStack[]{
+                new ItemStack(Materials.SPRUCE_PLANKS, Model.SLAB, 2),
+                new ItemStack(Materials.SPRUCE_PLANKS, Model.CYLINDER, 1) });
+
+        this.addResults(new ItemStack(Materials.DARK_PLANKS), new ItemStack[]{
+                new ItemStack(Materials.DARK_PLANKS, Model.SLAB, 2),
+                new ItemStack(Materials.DARK_PLANKS, Model.CYLINDER, 1) });
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/workbench/stone_cutter/StoneCutter.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/workbench/stone_cutter/StoneCutter.java
@@ -24,5 +24,47 @@ public class StoneCutter extends Workbench {
                 new ItemStack(Materials.COBBLE, Model.SLAB, 2),
                 new ItemStack(Materials.COBBLE, Model.CYLINDER, 1)
         });
+
+        this.addResults(new ItemStack(Materials.DARK_STONE, Model.BLOCK, 1), new ItemStack[]{
+                new ItemStack(Materials.DARK_COBBLE, Model.BLOCK, 1),
+                new ItemStack(Materials.DARK_STONE, Model.SLAB, 2),
+                new ItemStack(Materials.DARK_STONE_BRICK, Model.BLOCK, 1),
+                new ItemStack(Materials.DARK_STONE_BRICK, Model.CYLINDER, 1),
+                new ItemStack(Materials.DARK_STONE_BRICK, Model.SLAB, 2)
+        });
+
+        this.addResults(new ItemStack(Materials.DARK_COBBLE, Model.BLOCK, 1), new ItemStack[]{
+                new ItemStack(Materials.DARK_COBBLE, Model.SLAB, 2),
+                new ItemStack(Materials.DARK_COBBLE, Model.CYLINDER, 1)
+        });
+
+        this.addResults(new ItemStack(Materials.CALCITE, Model.BLOCK, 1), new ItemStack[]{
+                new ItemStack(Materials.CALCITE_BRICK, Model.BLOCK, 1),
+                new ItemStack(Materials.CALCITE, Model.SLAB, 2),
+                new ItemStack(Materials.CALCITE_BRICK, Model.CYLINDER, 1),
+                new ItemStack(Materials.CALCITE_BRICK, Model.SLAB, 2)
+        });
+
+        this.addResults(new ItemStack(Materials.CALCITE_BRICK, Model.BLOCK, 1), new ItemStack[]{
+                new ItemStack(Materials.CALCITE_BRICK, Model.SLAB, 2),
+                new ItemStack(Materials.CALCITE_BRICK, Model.CYLINDER, 1)
+        });
+
+        this.addResults(new ItemStack(Materials.BLACKSTONE, Model.BLOCK, 1), new ItemStack[]{
+                new ItemStack(Materials.POLISHED_BLACKSTONE_BRICKS, Model.BLOCK, 1),
+                new ItemStack(Materials.BLACKSTONE, Model.SLAB, 2),
+                new ItemStack(Materials.POLISHED_BLACKSTONE_BRICKS, Model.CYLINDER, 1),
+                new ItemStack(Materials.POLISHED_BLACKSTONE_BRICKS, Model.SLAB, 2)
+        });
+
+        this.addResults(new ItemStack(Materials.MUD_BRICKS, Model.BLOCK, 1), new ItemStack[]{
+                new ItemStack(Materials.MUD_BRICKS, Model.SLAB, 2),
+                new ItemStack(Materials.MUD_BRICKS, Model.CYLINDER, 1)
+        });
+
+        this.addResults(new ItemStack(Materials.STONE_DIORITE, Model.BLOCK, 1), new ItemStack[]{
+                new ItemStack(Materials.STONE_DIORITE, Model.SLAB, 2),
+                new ItemStack(Materials.STONE_DIORITE, Model.CYLINDER, 1)
+        });
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/workbench/tool_box/ToolBox.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/workbench/tool_box/ToolBox.java
@@ -41,6 +41,21 @@ public class ToolBox extends CenteredGUI implements ItemContainer {
         this.addResults(new ItemStack(Materials.STICK), new ItemStack(Materials.PLANKS, 2),
                 new ItemStack[]{ new ItemStack(Materials.WOODEN_AXE), new ItemStack(Materials.WOODEN_HOE), new ItemStack(Materials.WOODEN_PICKAXE), new ItemStack(Materials.WOODEN_SHOVEL), new ItemStack(Materials.WOODEN_SWORD) });
 
+        this.addResults(new ItemStack(Materials.STICK), new ItemStack(Materials.ACACIA_PLANKS, 2),
+                new ItemStack[]{ new ItemStack(Materials.WOODEN_AXE), new ItemStack(Materials.WOODEN_HOE), new ItemStack(Materials.WOODEN_PICKAXE), new ItemStack(Materials.WOODEN_SHOVEL), new ItemStack(Materials.WOODEN_SWORD) });
+
+        this.addResults(new ItemStack(Materials.STICK), new ItemStack(Materials.BIRCH_PLANKS, 2),
+                new ItemStack[]{ new ItemStack(Materials.WOODEN_AXE), new ItemStack(Materials.WOODEN_HOE), new ItemStack(Materials.WOODEN_PICKAXE), new ItemStack(Materials.WOODEN_SHOVEL), new ItemStack(Materials.WOODEN_SWORD) });
+
+        this.addResults(new ItemStack(Materials.STICK), new ItemStack(Materials.CHERRY_PLANKS, 2),
+                new ItemStack[]{ new ItemStack(Materials.WOODEN_AXE), new ItemStack(Materials.WOODEN_HOE), new ItemStack(Materials.WOODEN_PICKAXE), new ItemStack(Materials.WOODEN_SHOVEL), new ItemStack(Materials.WOODEN_SWORD) });
+
+        this.addResults(new ItemStack(Materials.STICK), new ItemStack(Materials.SPRUCE_PLANKS, 2),
+                new ItemStack[]{ new ItemStack(Materials.WOODEN_AXE), new ItemStack(Materials.WOODEN_HOE), new ItemStack(Materials.WOODEN_PICKAXE), new ItemStack(Materials.WOODEN_SHOVEL), new ItemStack(Materials.WOODEN_SWORD) });
+
+        this.addResults(new ItemStack(Materials.STICK), new ItemStack(Materials.DARK_PLANKS, 2),
+                new ItemStack[]{ new ItemStack(Materials.WOODEN_AXE), new ItemStack(Materials.WOODEN_HOE), new ItemStack(Materials.WOODEN_PICKAXE), new ItemStack(Materials.WOODEN_SHOVEL), new ItemStack(Materials.WOODEN_SWORD) });
+
         this.addResults(new ItemStack(Materials.STICK), new ItemStack(Materials.IRON_INGOT, 3),
                 new ItemStack[]{ new ItemStack(Materials.IRON_AXE), new ItemStack(Materials.IRON_PICKAXE), new ItemStack(Materials.IRON_SHOVEL), new ItemStack(Materials.IRON_SWORD), new ItemStack(Materials.BUCKET) });
 


### PR DESCRIPTION
## Summary
- expand `Sawmill` to convert additional wood types to planks
- extend `StoneCutter` with more stone variant outputs
- allow `ToolBox` to craft wooden tools from any plank type

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc3b5951c8330a695d459dd94e73e