### PR TITLE
Add death screen with respawn

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/entities/player/Player.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/entities/player/Player.java
@@ -16,6 +16,7 @@ import fr.rhumun.game.worldcraftopengl.worlds.Block;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Gui;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.player_inventory.PlayerInventoryGui;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.creative_inventory.CreativePlayerInventoryGui;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.death_menu.DeathGui;
 import fr.rhumun.game.worldcraftopengl.entities.physics.hitbox.AxisAlignedBB;
 import lombok.Getter;
 import lombok.Setter;
@@ -424,7 +425,20 @@ public class Player extends LivingEntity implements MovingEntity {
 
     @Override
     public void kill() {
-        //TO DO
+        this.openGui(new fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.death_menu.DeathGui());
+    }
+
+    /**
+     * Respawn the player at the world's spawn location with full health and hunger.
+     * Closes the death screen when done.
+     */
+    public void respawn() {
+        setHealth(getMaxHealth());
+        setFood(getMaxFood());
+        setSaturation(getMaxSaturation());
+        getWorld().spawnPlayer(this);
+        this.getVelocity().set(0, 0, 0);
+        this.closeInventory();
     }
 
     public boolean isHungry() {

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/death_menu/DeathGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/death_menu/DeathGui.java
@@ -1,0 +1,37 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.death_menu;
+
+import fr.rhumun.game.worldcraftopengl.content.textures.Texture;
+import fr.rhumun.game.worldcraftopengl.entities.player.Player;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.FullscreenTiledGui;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Button;
+
+import static fr.rhumun.game.worldcraftopengl.Game.GAME;
+
+/**
+ * GUI displayed when the player dies. It offers options to respawn or
+ * quit back to the title menu.
+ */
+public class DeathGui extends FullscreenTiledGui {
+
+    public DeathGui() {
+        super(Texture.DARK_COBBLE);
+
+        this.addText(0, -80, "Vous \u00eates mort");
+
+        this.addButton(new Button(0, 20, 400, 40, this, "R\u00e9apparaitre") {
+            @Override
+            public void onClick(Player player) {
+                player.respawn();
+            }
+        });
+
+        this.addButton(new Button(0, 80, 400, 40, this, "Quitter") {
+            @Override
+            public void onClick(Player player) {
+                GAME.quitWorld();
+            }
+        });
+
+        this.setAlignCenter(true);
+    }
+}


### PR DESCRIPTION
## Summary
- add a death GUI with respawn and quit buttons
- implement player respawn logic
- open the death screen when the player dies

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdc5120bc83308167029d45f333bd