### PR TITLE
Add settings GUI

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GuiModule.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/GuiModule.java
@@ -206,7 +206,7 @@ public class GuiModule {
 
         for(Component component : this.gui.getComponents()){
             if(component instanceof ClickableSlot slot) {
-                if(component.isCursorIn()){
+                if(component.isCursorIn() && component.isVisible()){
                     ItemStack selected = getSelectedItem();
                     if(selected == null) break;
 
@@ -231,7 +231,7 @@ public class GuiModule {
 
         for(Component component : this.gui.getComponents()){
             if(component instanceof Button button) {
-                if(component.isCursorIn()){
+                if(component.isCursorIn() && component.isVisible()){
                     button.click(player);
                     break;
                 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Checkbox.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/components/Checkbox.java
@@ -28,10 +28,6 @@ public class Checkbox extends Button {
         this.uncheckedHover = Texture.CHECKBOX_HIGHLIGHTED;
         this.checkedTex = Texture.CHECKBOX_SELECTED;
         this.checkedHover = Texture.CHECKBOX_SELECTED_HIGHLIGHTED;
-
-        this.getText().setText(label);
-        this.getText().set2DCoordinates(-40, 0);
-        this.setAlignCenter(true);
     }
 
     @Override

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/PauseGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/PauseGui.java
@@ -5,6 +5,7 @@ import fr.rhumun.game.worldcraftopengl.entities.player.Player;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.CenteredGUI;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Button;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.title_menu.QuitButton;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.pause_menu.SettingsGui;
 
 import static fr.rhumun.game.worldcraftopengl.Game.GAME;
 
@@ -25,13 +26,8 @@ public class PauseGui extends CenteredGUI {
         this.addButton(new Button(0, 40, 400, 40, this, "Parametres") {
 
             @Override
-            public boolean isActive(){
-                return false;
-            }
-
-            @Override
             public void onClick(Player player) {
-
+                GAME.getGraphicModule().getGuiModule().openGUI(new SettingsGui());
             }
         });
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/SettingsGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/SettingsGui.java
@@ -19,22 +19,26 @@ public class SettingsGui extends CenteredGUI {
 
         this.addText(0, -160, "Parametres");
 
-        Checkbox vsync = new Checkbox(-200, -80, "V-Sync", this);
+        Checkbox vsync = new Checkbox(-100, -80, "V-Sync", this);
+        this.addText(50, -80, "V-Sync");
         vsync.setChecked(Game.ENABLE_VSYNC);
         vsync.setOnChange(() -> Game.ENABLE_VSYNC = vsync.isChecked());
         this.addButton(vsync);
 
-        Checkbox greedy = new Checkbox(-200, -30, "Greedy Meshing", this);
+        Checkbox greedy = new Checkbox(-100, -30, "Greedy Meshing", this);
+        this.addText(50, -30, "Greedy meshing");
         greedy.setChecked(Game.GREEDY_MESHING);
         greedy.setOnChange(() -> Game.GREEDY_MESHING = greedy.isChecked());
         this.addButton(greedy);
 
-        Checkbox debug = new Checkbox(-200, 20, "Debug", this);
+        Checkbox debug = new Checkbox(-100, 20, "Debug", this);
+        this.addText(50, 20, "Debug");
         debug.setChecked(Game.DEBUG);
         debug.setOnChange(() -> Game.DEBUG = debug.isChecked());
         this.addButton(debug);
 
-        Checkbox creative = new Checkbox(-200, 70, "Mode Creatif", this);
+        Checkbox creative = new Checkbox(-100, 70, "Mode Creatif", this);
+        this.addText(50, 70, "Mode Creatif");
         creative.setChecked(GAME.getPlayer().getGamemode() == Gamemode.CREATIVE);
         creative.setOnChange(() -> GAME.getPlayer().setGamemode(
                 creative.isChecked() ? Gamemode.CREATIVE : Gamemode.SURVIVAL));

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/SettingsGui.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/guis/types/pause_menu/SettingsGui.java
@@ -1,0 +1,52 @@
+package fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.types.pause_menu;
+
+import fr.rhumun.game.worldcraftopengl.Game;
+import fr.rhumun.game.worldcraftopengl.entities.player.Gamemode;
+import fr.rhumun.game.worldcraftopengl.entities.player.Player;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.CenteredGUI;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Button;
+import fr.rhumun.game.worldcraftopengl.outputs.graphic.guis.components.Checkbox;
+
+import static fr.rhumun.game.worldcraftopengl.Game.GAME;
+
+/**
+ * Simple settings menu allowing toggling of a few runtime options.
+ */
+public class SettingsGui extends CenteredGUI {
+
+    public SettingsGui() {
+        super(500, 400, null);
+
+        this.addText(0, -160, "Parametres");
+
+        Checkbox vsync = new Checkbox(-200, -80, "V-Sync", this);
+        vsync.setChecked(Game.ENABLE_VSYNC);
+        vsync.setOnChange(() -> Game.ENABLE_VSYNC = vsync.isChecked());
+        this.addButton(vsync);
+
+        Checkbox greedy = new Checkbox(-200, -30, "Greedy Meshing", this);
+        greedy.setChecked(Game.GREEDY_MESHING);
+        greedy.setOnChange(() -> Game.GREEDY_MESHING = greedy.isChecked());
+        this.addButton(greedy);
+
+        Checkbox debug = new Checkbox(-200, 20, "Debug", this);
+        debug.setChecked(Game.DEBUG);
+        debug.setOnChange(() -> Game.DEBUG = debug.isChecked());
+        this.addButton(debug);
+
+        Checkbox creative = new Checkbox(-200, 70, "Mode Creatif", this);
+        creative.setChecked(GAME.getPlayer().getGamemode() == Gamemode.CREATIVE);
+        creative.setOnChange(() -> GAME.getPlayer().setGamemode(
+                creative.isChecked() ? Gamemode.CREATIVE : Gamemode.SURVIVAL));
+        this.addButton(creative);
+
+        this.addButton(new Button(0, 140, 400, 40, this, "Retour") {
+            @Override
+            public void onClick(Player player) {
+                GAME.getGraphicModule().getGuiModule().openGUI(new PauseGui());
+            }
+        });
+
+        this.setAlignCenter(true);
+    }
+}


### PR DESCRIPTION
## Summary
- add SettingsGui menu with toggles for V-Sync, greedy meshing, debug and player gamemode
- enable "Parametres" button in PauseGui to open the new settings menu

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685be4919b408330a61f61ae392c2a8e