### PR TITLE
Optimize buffer usage

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/BreakingBlockRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/BreakingBlockRenderer.java
@@ -34,9 +34,10 @@ public class BreakingBlockRenderer extends GlobalRenderer {
 
         glBindVertexArray(this.getVAO());
         glBindBuffer(GL_ARRAY_BUFFER, this.getVBO());
-        glBufferData(GL_ARRAY_BUFFER, this.getVerticesArray().clone(), GL_STATIC_DRAW);
+        fillBuffers();
+        glBufferData(GL_ARRAY_BUFFER, this.getVerticesBuffer(), GL_DYNAMIC_DRAW);
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.getEBO());
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesArray().clone(), GL_STATIC_DRAW);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesBuffer(), GL_DYNAMIC_DRAW);
 
         glEnable(GL_POLYGON_OFFSET_FILL);
         glPolygonOffset(-1f, -1f);
@@ -114,5 +115,10 @@ public class BreakingBlockRenderer extends GlobalRenderer {
     private void addVertex(float[] vertexData) {
         getVertices().add(vertexData);
         addIndice();
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/ChunkRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/ChunkRenderer.java
@@ -25,7 +25,7 @@ import java.util.LinkedHashSet;
 
 import static fr.rhumun.game.worldcraftopengl.Game.*;
 import static org.lwjgl.opengl.GL15.*;
-import static org.lwjgl.opengl.GL15.GL_STATIC_DRAW;
+import static org.lwjgl.opengl.GL15.GL_DYNAMIC_DRAW;
 import static org.lwjgl.opengl.GL30C.glBindVertexArray;
 
 @Getter
@@ -118,13 +118,14 @@ public class ChunkRenderer extends AbstractChunkRenderer{
         this.getRenderers().getFirst().getGraphicModule().getLightningsUtils().updateLights();
 
         for(Renderer renderer : this.getRenderers()) {
-            glBindVertexArray(renderer.getVAO());
+           glBindVertexArray(renderer.getVAO());
 
-            glBindBuffer(GL_ARRAY_BUFFER, renderer.getVBO());
-            glBufferData(GL_ARRAY_BUFFER, renderer.getVerticesArray().clone(), GL_STATIC_DRAW);
+           glBindBuffer(GL_ARRAY_BUFFER, renderer.getVBO());
+            renderer.fillBuffers();
+            glBufferData(GL_ARRAY_BUFFER, renderer.getVerticesBuffer(), GL_DYNAMIC_DRAW);
 
-            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, renderer.getEBO());
-            glBufferData(GL_ELEMENT_ARRAY_BUFFER, renderer.getIndicesArray().clone(), GL_STATIC_DRAW);
+           glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, renderer.getEBO());
+            glBufferData(GL_ELEMENT_ARRAY_BUFFER, renderer.getIndicesBuffer(), GL_DYNAMIC_DRAW);
 
             glBindVertexArray(0);
         }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/EntitiesRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/EntitiesRenderer.java
@@ -19,7 +19,7 @@ import java.util.Iterator;
 
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.opengl.GL15.*;
-import static org.lwjgl.opengl.GL15.GL_STATIC_DRAW;
+import static org.lwjgl.opengl.GL15.GL_DYNAMIC_DRAW;
 import static org.lwjgl.opengl.GL30.glBindVertexArray;
 
 public class EntitiesRenderer extends GlobalRenderer {
@@ -37,10 +37,11 @@ public class EntitiesRenderer extends GlobalRenderer {
 
         glBindVertexArray(this.getVAO());
         glBindBuffer(GL_ARRAY_BUFFER, this.getVBO());
-        glBufferData(GL_ARRAY_BUFFER, this.getVerticesArray().clone(), GL_STATIC_DRAW);
+        fillBuffers();
+        glBufferData(GL_ARRAY_BUFFER, this.getVerticesBuffer(), GL_DYNAMIC_DRAW);
 
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.getEBO());
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesArray().clone(), GL_STATIC_DRAW);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesBuffer(), GL_DYNAMIC_DRAW);
 
         glDrawElements(GL_TRIANGLES, this.getIndicesArray().length, GL_UNSIGNED_INT, 0);
 
@@ -144,5 +145,10 @@ public class EntitiesRenderer extends GlobalRenderer {
     private void addVertex(float[] vertexData) {
         this.getVertices().add(vertexData);
         this.addIndice();
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/GlobalRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/GlobalRenderer.java
@@ -69,5 +69,6 @@ public class GlobalRenderer extends Renderer {
         glDeleteBuffers(this.getVBO());
         glDeleteVertexArrays(this.getVAO());
         glDeleteBuffers(this.getEBO());
+        freeBuffers();
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/HitboxRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/HitboxRenderer.java
@@ -129,10 +129,11 @@ public class HitboxRenderer extends Renderer {
         glBindVertexArray(this.getVAO());
 
         glBindBuffer(GL_ARRAY_BUFFER, this.getVBO());
-        glBufferData(GL_ARRAY_BUFFER, this.getVerticesArray().clone(), GL_STATIC_DRAW);
+        fillBuffers();
+        glBufferData(GL_ARRAY_BUFFER, this.getVerticesBuffer(), GL_DYNAMIC_DRAW);
 
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.getEBO());
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesArray().clone(), GL_STATIC_DRAW);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesBuffer(), GL_DYNAMIC_DRAW);
 
         glBindVertexArray(0);
     }
@@ -142,5 +143,6 @@ public class HitboxRenderer extends Renderer {
         glDeleteBuffers(this.getVBO());
         glDeleteVertexArrays(this.getVAO());
         glDeleteBuffers(this.getEBO());
+        freeBuffers();
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/MobEntitiesRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/MobEntitiesRenderer.java
@@ -15,7 +15,7 @@ import java.util.Iterator;
 
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.opengl.GL15.*;
-import static org.lwjgl.opengl.GL15.GL_STATIC_DRAW;
+import static org.lwjgl.opengl.GL15.GL_DYNAMIC_DRAW;
 import static org.lwjgl.opengl.GL30.glBindVertexArray;
 
 public class MobEntitiesRenderer extends GlobalRenderer {
@@ -33,10 +33,10 @@ public class MobEntitiesRenderer extends GlobalRenderer {
 
         glBindVertexArray(this.getVAO());
         glBindBuffer(GL_ARRAY_BUFFER, this.getVBO());
-        glBufferData(GL_ARRAY_BUFFER, this.getVerticesArray().clone(), GL_STATIC_DRAW);
-//
+        fillBuffers();
+        glBufferData(GL_ARRAY_BUFFER, this.getVerticesBuffer(), GL_DYNAMIC_DRAW);
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.getEBO());
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesArray().clone(), GL_STATIC_DRAW);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesBuffer(), GL_DYNAMIC_DRAW);
 //
         glDrawElements(GL_TRIANGLES, this.getIndicesArray().length, GL_UNSIGNED_INT, 0);
 //
@@ -124,5 +124,10 @@ public class MobEntitiesRenderer extends GlobalRenderer {
     private void addVertex(float[] vertexData) {
         this.getVertices().add(vertexData);
         this.addIndice();
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/Renderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/Renderer.java
@@ -5,6 +5,8 @@ import fr.rhumun.game.worldcraftopengl.outputs.graphic.shaders.Shader;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -12,6 +14,7 @@ import java.util.List;
 import static org.lwjgl.opengl.GL15.glGenBuffers;
 import static org.lwjgl.opengl.GL30.glBindVertexArray;
 import static org.lwjgl.opengl.GL30.glGenVertexArrays;
+import static org.lwjgl.system.MemoryUtil.*;
 
 @Getter
 @Setter
@@ -23,9 +26,12 @@ public abstract class Renderer {
     private final ArrayList<float[]> vertices = new ArrayList<>();
     private float[] verticesArray = new float[0];
 
+    private FloatBuffer verticesBuffer;
+
     private final ArrayList<Integer> indices = new ArrayList<>();
     private int indice;
     int[] indicesArray = new int[0];
+    private IntBuffer indicesBuffer;
 
     public Renderer(GraphicModule graphicModule, Shader shader) {
         //System.out.println("Creating Renderer");
@@ -77,6 +83,33 @@ public abstract class Renderer {
         VAO = glGenVertexArrays();
         VBO = glGenBuffers();
         EBO = glGenBuffers();
+    }
+
+    protected void fillBuffers() {
+        if(verticesBuffer == null || verticesBuffer.capacity() < verticesArray.length) {
+            if(verticesBuffer != null) memFree(verticesBuffer);
+            verticesBuffer = memAllocFloat(verticesArray.length);
+        }
+        verticesBuffer.clear();
+        verticesBuffer.put(verticesArray).flip();
+
+        if(indicesBuffer == null || indicesBuffer.capacity() < indicesArray.length) {
+            if(indicesBuffer != null) memFree(indicesBuffer);
+            indicesBuffer = memAllocInt(indicesArray.length);
+        }
+        indicesBuffer.clear();
+        indicesBuffer.put(indicesArray).flip();
+    }
+
+    protected void freeBuffers() {
+        if(verticesBuffer != null) {
+            memFree(verticesBuffer);
+            verticesBuffer = null;
+        }
+        if(indicesBuffer != null) {
+            memFree(indicesBuffer);
+            indicesBuffer = null;
+        }
     }
 
     public abstract void render();


### PR DESCRIPTION
## Summary
- use persistent vertex/index buffers in `Renderer`
- update various renderers to fill and reuse these buffers
- free the buffers in cleanup methods

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685bedeb1570833084ce67c834c67462