### PR TITLE
Enable skeletal animation rendering

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Animator.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Animator.java
@@ -57,7 +57,8 @@ public class Animator {
 
     public void sendToShader(Shader shader) {
         for (Bone bone : bones.values()) {
-            shader.setUniform("boneMatrices[" + bone.index + "]", bone.globalTransform);
+            Matrix4f mat = new Matrix4f(bone.globalTransform).mul(bone.offsetMatrix);
+            shader.setUniform("boneMatrices[" + bone.index + "]", mat);
         }
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Bone.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Bone.java
@@ -19,6 +19,7 @@ public class Bone {
 
     public final Matrix4f localTransform = new Matrix4f();
     public final Matrix4f globalTransform = new Matrix4f();
+    public final Matrix4f offsetMatrix = new Matrix4f();
 
     public Bone(String name, int index) {
         this.name = name;
@@ -38,6 +39,10 @@ public class Bone {
     public void setScale(Vector3f s) {
         this.scale.set(s);
         recomputeMatrix();
+    }
+
+    public void setBindMatrix(Matrix4f mat) {
+        this.localTransform.set(mat);
     }
 
     public void recomputeMatrix() {

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/GlobalRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/GlobalRenderer.java
@@ -37,21 +37,26 @@ public class GlobalRenderer extends Renderer {
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.getEBO());
 
         // Attributs communs
-        glVertexAttribPointer(0, 3, GL_FLOAT, false, (useSkinning ? 10 : 9) * Float.BYTES, 0);
+        int stride = (useSkinning ? 17 : 9) * Float.BYTES;
+
+        glVertexAttribPointer(0, 3, GL_FLOAT, false, stride, 0);
         glEnableVertexAttribArray(0);
 
-        glVertexAttribPointer(1, 2, GL_FLOAT, false, (useSkinning ? 10 : 9) * Float.BYTES, 3 * Float.BYTES);
+        glVertexAttribPointer(1, 2, GL_FLOAT, false, stride, 3 * Float.BYTES);
         glEnableVertexAttribArray(1);
 
-        glVertexAttribPointer(2, 1, GL_FLOAT, false, (useSkinning ? 10 : 9) * Float.BYTES, 5 * Float.BYTES);
+        glVertexAttribPointer(2, 1, GL_FLOAT, false, stride, 5 * Float.BYTES);
         glEnableVertexAttribArray(2);
 
-        glVertexAttribPointer(3, 3, GL_FLOAT, false, (useSkinning ? 10 : 9) * Float.BYTES, 6 * Float.BYTES);
+        glVertexAttribPointer(3, 3, GL_FLOAT, false, stride, 6 * Float.BYTES);
         glEnableVertexAttribArray(3);
 
         if (useSkinning) {
-            glVertexAttribIPointer(4, 1, GL_INT, 10 * Float.BYTES, 9 * Float.BYTES);
+            glVertexAttribPointer(4, 4, GL_FLOAT, false, stride, 9 * Float.BYTES);
             glEnableVertexAttribArray(4);
+
+            glVertexAttribPointer(5, 4, GL_FLOAT, false, stride, 9 * Float.BYTES + 4 * Float.BYTES);
+            glEnableVertexAttribArray(5);
         }
 
         glBindVertexArray(0);

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/MobEntitiesRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/MobEntitiesRenderer.java
@@ -37,13 +37,12 @@ public class MobEntitiesRenderer extends GlobalRenderer {
         glBufferData(GL_ARRAY_BUFFER, this.getVerticesBuffer(), GL_DYNAMIC_DRAW);
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.getEBO());
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesBuffer(), GL_DYNAMIC_DRAW);
-//
+
         glDrawElements(GL_TRIANGLES, this.getIndicesArray().length, GL_UNSIGNED_INT, 0);
-//
+
         glBindBuffer(GL_ARRAY_BUFFER, 0);
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
         glBindVertexArray(0);
-//
         this.getIndices().clear();
         this.getVertices().clear();
     }
@@ -79,7 +78,8 @@ public class MobEntitiesRenderer extends GlobalRenderer {
         FloatBuffer nBuf = obj.getNormalsBuffer().duplicate();
         FloatBuffer tBuf = obj.getTexCoordsBuffer().duplicate();
         IntBuffer iBuf = obj.getIndicesBuffer().duplicate();
-        IntBuffer boneBuf = obj.getBoneIDsBuffer().duplicate();
+        FloatBuffer boneBuf = obj.getBoneIDsBuffer().duplicate();
+        FloatBuffer weightBuf = obj.getBoneWeightsBuffer().duplicate();
 
         float yawRad = (float) Math.toRadians(entity.getLocation().getYaw());
         float cosYaw = (float) Math.cos(yawRad);
@@ -113,10 +113,26 @@ public class MobEntitiesRenderer extends GlobalRenderer {
             float u = tBuf.get(idx * 2);
             float v = tBuf.get(idx * 2 + 1);
 
-            int boneID = boneBuf.get(idx);
             int texture = entity.getTextureID();
 
-            float[] vertex = new float[]{vx, vy, vz, u, v, texture, rnx, ny, rnz, boneID};
+            float id0 = boneBuf.get(idx * 4);
+            float id1 = boneBuf.get(idx * 4 + 1);
+            float id2 = boneBuf.get(idx * 4 + 2);
+            float id3 = boneBuf.get(idx * 4 + 3);
+
+            float w0 = weightBuf.get(idx * 4);
+            float w1 = weightBuf.get(idx * 4 + 1);
+            float w2 = weightBuf.get(idx * 4 + 2);
+            float w3 = weightBuf.get(idx * 4 + 3);
+
+            float[] vertex = new float[]{
+                    vx, vy, vz,
+                    u, v,
+                    texture,
+                    rnx, ny, rnz,
+                    id0, id1, id2, id3,
+                    w0, w1, w2, w3
+            };
             this.addVertex(vertex);
         }
     }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/shaders/game/animated_entity_shader.glsl
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/shaders/game/animated_entity_shader.glsl
@@ -5,7 +5,8 @@ layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec2 inTexCoord;
 layout(location = 2) in float inTextureIndex;
 layout(location = 3) in vec3 inNormal;
-layout(location = 4) in int inBoneID;
+layout(location = 4) in vec4 inBoneIDs;
+layout(location = 5) in vec4 inWeights;
 
 uniform mat4 projection;
 uniform mat4 view;
@@ -16,12 +17,15 @@ out float fragTextureIndex;
 out vec3 fragNormal;
 
 void main() {
-    mat4 boneTransform = boneMatrices[inBoneID];
-    vec4 worldPos = boneTransform * vec4(inPosition, 1.0);
+    mat4 skinMatrix = 
+        inWeights.x * boneMatrices[int(inBoneIDs.x)] +
+        inWeights.y * boneMatrices[int(inBoneIDs.y)] +
+        inWeights.z * boneMatrices[int(inBoneIDs.z)] +
+        inWeights.w * boneMatrices[int(inBoneIDs.w)];
+    vec4 worldPos = skinMatrix * vec4(inPosition, 1.0);
     fragTexCoord = inTexCoord;
     fragTextureIndex = inTextureIndex;
-    fragNormal = mat3(transpose(inverse(boneTransform))) * inNormal;
-    vec4 skinnedPos = boneMatrices[inBoneID] * vec4(inPosition, 1.0);
-    skinnedPos.xyz *= 0.05; // Réduit l’échelle
-    gl_Position = projection * view * worldPos * skinnedPos;
+    fragNormal = mat3(transpose(inverse(skinMatrix))) * inNormal;
+    worldPos.xyz *= 0.05;
+    gl_Position = projection * view * worldPos;
 }


### PR DESCRIPTION
## Summary
- parse bone weights and IDs in `Mesh.loadSkinnedMesh`
- store bone offset matrices and hierarchy with `GltfAnimationLoader`
- compute final bone matrices in `Animator`
- expose bind matrices in `Bone`
- adjust GL attribute layout for skinning
- render animated entities with bone matrices
- update GLSL vertex shader for GPU skinning

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685c9a5ba81c833085973f3cc42805dd