### PR TITLE
Enable skeletal animation rendering

### DIFF
--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Animation.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Animation.java
@@ -1,0 +1,17 @@
+package fr.rhumun.game.worldcraftopengl.content.models.entities;
+
+import java.util.List;
+
+public class Animation {
+    public final String name;
+    public final float duration;
+    public final float ticksPerSecond;
+    public final List<AnimationChannel<?>> channels;
+
+    public Animation(String name, float duration, float ticksPerSecond, List<AnimationChannel<?>> channels) {
+        this.name = name;
+        this.duration = duration;
+        this.ticksPerSecond = ticksPerSecond == 0 ? 1f : ticksPerSecond;
+        this.channels = channels;
+    }
+}

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Animator.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Animator.java
@@ -57,7 +57,8 @@ public class Animator {
 
     public void sendToShader(Shader shader) {
         for (Bone bone : bones.values()) {
-            shader.setUniform("boneMatrices[" + bone.index + "]", bone.globalTransform);
+            Matrix4f mat = new Matrix4f(bone.globalTransform).mul(bone.offsetMatrix);
+            shader.setUniform("boneMatrices[" + bone.index + "]", mat);
         }
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Animator.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Animator.java
@@ -5,6 +5,7 @@ import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -13,22 +14,37 @@ import static fr.rhumun.game.worldcraftopengl.content.models.entities.Keyframe.i
 
 public class Animator {
     private final Map<String, Bone> bones;
-    private final List<AnimationChannel<?>> channels;
+    private final Map<String, Animation> animations;
+    private Animation currentAnimation;
     private float animationTime = 0f;
     private float animationSpeed = 1f;
 
-    public Animator(Map<String, Bone> bones, List<AnimationChannel<?>> channels) {
+    public Animator(Map<String, Bone> bones, Map<String, Animation> animations) {
         this.bones = bones;
-        this.channels = channels;
+        this.animations = new LinkedHashMap<>(animations);
+        if (!animations.isEmpty()) {
+            this.currentAnimation = animations.values().iterator().next();
+        }
+    }
+
+    public void play(String name) {
+        Animation anim = animations.get(name);
+        if (anim != null && anim != currentAnimation) {
+            currentAnimation = anim;
+            animationTime = 0f;
+        }
     }
 
     public void update(float deltaTime) {
+        if (currentAnimation == null) return;
         animationTime += deltaTime * animationSpeed;
-        applyAnimation(animationTime);
+        float durationSec = currentAnimation.duration / currentAnimation.ticksPerSecond;
+        float localTime = animationTime % durationSec;
+        applyAnimation(currentAnimation, localTime * currentAnimation.ticksPerSecond);
     }
 
-    public void applyAnimation(float time) {
-        for (AnimationChannel<?> channel : channels) {
+    private void applyAnimation(Animation animation, float time) {
+        for (AnimationChannel<?> channel : animation.channels) {
             Bone bone = bones.get(channel.targetNodeName);
             if (bone == null) continue;
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Bone.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Bone.java
@@ -19,6 +19,7 @@ public class Bone {
 
     public final Matrix4f localTransform = new Matrix4f();
     public final Matrix4f globalTransform = new Matrix4f();
+    public final Matrix4f offsetMatrix = new Matrix4f();
 
     public Bone(String name, int index) {
         this.name = name;
@@ -38,6 +39,10 @@ public class Bone {
     public void setScale(Vector3f s) {
         this.scale.set(s);
         recomputeMatrix();
+    }
+
+    public void setBindMatrix(Matrix4f mat) {
+        this.localTransform.set(mat);
     }
 
     public void recomputeMatrix() {

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Bone.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/Bone.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public class Bone {
     public final String name;
-    public final int index;
+    public int index;
     public Bone parent;
     public final List<Bone> children = new ArrayList<>();
 
@@ -17,7 +17,12 @@ public class Bone {
     private final Quaternionf rotation = new Quaternionf();
     private final Vector3f scale = new Vector3f(1, 1, 1);
 
+    private final Vector3f bindTranslation = new Vector3f();
+    private final Quaternionf bindRotation = new Quaternionf();
+    private final Vector3f bindScale = new Vector3f(1, 1, 1);
+
     public final Matrix4f localTransform = new Matrix4f();
+    public final Matrix4f bindTransform = new Matrix4f();
     public final Matrix4f globalTransform = new Matrix4f();
     public final Matrix4f offsetMatrix = new Matrix4f();
 
@@ -42,7 +47,21 @@ public class Bone {
     }
 
     public void setBindMatrix(Matrix4f mat) {
-        this.localTransform.set(mat);
+        this.bindTransform.set(mat);
+        mat.getTranslation(bindTranslation);
+        mat.getUnnormalizedRotation(bindRotation);
+        mat.getScale(bindScale);
+        translation.set(bindTranslation);
+        rotation.set(bindRotation);
+        scale.set(bindScale);
+        recomputeMatrix();
+    }
+
+    public void resetToBindPose() {
+        translation.set(bindTranslation);
+        rotation.set(bindRotation);
+        scale.set(bindScale);
+        recomputeMatrix();
     }
 
     public void recomputeMatrix() {
@@ -52,10 +71,13 @@ public class Bone {
                 .scale(scale);
     }
 
-    public void computeGlobalTransform() {
+    public void computeGlobalTransformRecursive() {
         if (parent != null)
             globalTransform.set(parent.globalTransform).mul(localTransform);
         else
             globalTransform.set(localTransform);
+        for (Bone child : children) {
+            child.computeGlobalTransformRecursive();
+        }
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/GltfAnimationLoader.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/content/models/entities/GltfAnimationLoader.java
@@ -35,7 +35,8 @@ public class GltfAnimationLoader {
             for (int i = 0; i < mesh.mNumBones(); i++) {
                 AIBone aiBone = AIBone.create(aiBones.get(i));
                 String name = aiBone.mName().dataString();
-                Bone b = bones.computeIfAbsent(name, n -> new Bone(n, bones.size()));
+                Bone b = bones.computeIfAbsent(name, n -> new Bone(n, i));
+                if (b.index < 0) b.index = i;
                 AIMatrix4x4 mat = aiBone.mOffsetMatrix();
                 b.offsetMatrix.set(
                         mat.a1(), mat.b1(), mat.c1(), mat.d1(),
@@ -98,7 +99,7 @@ public class GltfAnimationLoader {
 
     private static void processNodes(AINode node, Bone parent, Map<String, Bone> bones) {
         String name = node.mName().dataString();
-        Bone bone = bones.computeIfAbsent(name, n -> new Bone(n, bones.size()));
+        Bone bone = bones.computeIfAbsent(name, n -> new Bone(n, -1));
         bone.parent = parent;
         if (parent != null) parent.children.add(bone);
 

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/entities/NinjaSkeletonEntity.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/entities/NinjaSkeletonEntity.java
@@ -14,7 +14,8 @@ public class NinjaSkeletonEntity extends MobEntity {
 
         var result = GltfAnimationLoader.load("models\\ninja_skeleton.gltf");
         if (result != null) {
-            this.setAnimator(new Animator(result.bones(), result.channels()));
+            this.setAnimator(new Animator(result.bones(), result.animations()));
+            getAnimator().play("idle");
         }
     }
 
@@ -26,7 +27,9 @@ public class NinjaSkeletonEntity extends MobEntity {
 
     @Override
     public void move() {
-        if (getAnimator() != null) getAnimator().update(1f / 60f);
+        if (getAnimator() != null) {
+            getAnimator().update(1f / 60f);
+        }
 
         Player player = Game.GAME.getPlayer();
         if (player != null) {
@@ -48,5 +51,10 @@ public class NinjaSkeletonEntity extends MobEntity {
         if(this.hasBlockInViewDirection()) { this. jump();}
 
         Movements.applyMovements(this);
+
+        if (getAnimator() != null) {
+            boolean movingNow = getMovements()[0] != 0 || getMovements()[2] != 0;
+            getAnimator().play(movingNow ? "walk" : "idle");
+        }
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/entities/RockyEntity.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/entities/RockyEntity.java
@@ -14,7 +14,8 @@ public class RockyEntity extends MobEntity {
 
         var result = GltfAnimationLoader.load("models\\Rocky.gltf");
         if (result != null) {
-            this.setAnimator(new Animator(result.bones(), result.channels()));
+            this.setAnimator(new Animator(result.bones(), result.animations()));
+            getAnimator().play("idle");
         }
     }
 
@@ -25,7 +26,9 @@ public class RockyEntity extends MobEntity {
 
     @Override
     public void move() {
-        if (getAnimator() != null) getAnimator().update(1f / 60f);
+        if (getAnimator() != null) {
+            getAnimator().update(1f / 60f);
+        }
 
         var world = Game.GAME.getWorld();
         NinjaSkeletonEntity target = null;
@@ -57,5 +60,10 @@ public class RockyEntity extends MobEntity {
         }
 
         Movements.applyMovements(this);
+
+        if (getAnimator() != null) {
+            boolean moving = getMovements()[0] != 0 || getMovements()[2] != 0;
+            getAnimator().play(moving ? "walk" : "idle");
+        }
     }
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/GlobalRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/GlobalRenderer.java
@@ -37,21 +37,26 @@ public class GlobalRenderer extends Renderer {
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.getEBO());
 
         // Attributs communs
-        glVertexAttribPointer(0, 3, GL_FLOAT, false, (useSkinning ? 10 : 9) * Float.BYTES, 0);
+        int stride = (useSkinning ? 17 : 9) * Float.BYTES;
+
+        glVertexAttribPointer(0, 3, GL_FLOAT, false, stride, 0);
         glEnableVertexAttribArray(0);
 
-        glVertexAttribPointer(1, 2, GL_FLOAT, false, (useSkinning ? 10 : 9) * Float.BYTES, 3 * Float.BYTES);
+        glVertexAttribPointer(1, 2, GL_FLOAT, false, stride, 3 * Float.BYTES);
         glEnableVertexAttribArray(1);
 
-        glVertexAttribPointer(2, 1, GL_FLOAT, false, (useSkinning ? 10 : 9) * Float.BYTES, 5 * Float.BYTES);
+        glVertexAttribPointer(2, 1, GL_FLOAT, false, stride, 5 * Float.BYTES);
         glEnableVertexAttribArray(2);
 
-        glVertexAttribPointer(3, 3, GL_FLOAT, false, (useSkinning ? 10 : 9) * Float.BYTES, 6 * Float.BYTES);
+        glVertexAttribPointer(3, 3, GL_FLOAT, false, stride, 6 * Float.BYTES);
         glEnableVertexAttribArray(3);
 
         if (useSkinning) {
-            glVertexAttribIPointer(4, 1, GL_INT, 10 * Float.BYTES, 9 * Float.BYTES);
+            glVertexAttribPointer(4, 4, GL_FLOAT, false, stride, 9 * Float.BYTES);
             glEnableVertexAttribArray(4);
+
+            glVertexAttribPointer(5, 4, GL_FLOAT, false, stride, 9 * Float.BYTES + 4 * Float.BYTES);
+            glEnableVertexAttribArray(5);
         }
 
         glBindVertexArray(0);

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/MobEntitiesRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/MobEntitiesRenderer.java
@@ -6,6 +6,7 @@ import fr.rhumun.game.worldcraftopengl.entities.MobEntity;
 import fr.rhumun.game.worldcraftopengl.entities.player.Player;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.GraphicModule;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.utils.ShaderManager;
+import org.joml.Matrix4f;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.util.Iterator;
@@ -50,6 +51,12 @@ public class MobEntitiesRenderer extends GlobalRenderer {
             ShaderManager.ANIMATED_ENTITY_SHADER.use();
             mob.getAnimator().sendToShader(ShaderManager.ANIMATED_ENTITY_SHADER);
 
+            Matrix4f modelMat = new Matrix4f()
+                    .translate((float) mob.getLocation().getX(), (float) mob.getLocation().getY(), (float) mob.getLocation().getZ())
+                    .rotateY((float) Math.toRadians(mob.getLocation().getYaw()))
+                    .scale(0.05f);
+            ShaderManager.ANIMATED_ENTITY_SHADER.setUniform("model", modelMat);
+
             glBufferData(GL_ARRAY_BUFFER, this.getVerticesBuffer(), GL_DYNAMIC_DRAW);
             glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesBuffer(), GL_DYNAMIC_DRAW);
             glDrawElements(GL_TRIANGLES, this.getIndicesArray().length, GL_UNSIGNED_INT, 0);
@@ -74,34 +81,21 @@ public class MobEntitiesRenderer extends GlobalRenderer {
         FloatBuffer boneBuf = obj.getBoneIDsBuffer().duplicate();
         FloatBuffer weightBuf = obj.getBoneWeightsBuffer().duplicate();
 
-        float yawRad = (float) Math.toRadians(entity.getLocation().getYaw());
-        float cosYaw = (float) Math.cos(yawRad);
-        float sinYaw = (float) Math.sin(yawRad);
-
-        double x = entity.getLocation().getX();
-        double y = entity.getLocation().getY();
-        double z = entity.getLocation().getZ();
-
         while (iBuf.hasRemaining()) {
             int idx = iBuf.get();
 
             float relX = vBuf.get(idx * 3);
             float relY = vBuf.get(idx * 3 + 1);
             float relZ = vBuf.get(idx * 3 + 2);
-
-            float rotX = cosYaw * relX - sinYaw * relZ;
-            float rotZ = sinYaw * relX + cosYaw * relZ;
-
-            float vx = (float) (x + rotX);
-            float vy = (float) (y + relY);
-            float vz = (float) (z + rotZ);
+            float vx = relX;
+            float vy = relY;
+            float vz = relZ;
 
             float nx = nBuf.get(idx * 3);
             float ny = nBuf.get(idx * 3 + 1);
             float nz = nBuf.get(idx * 3 + 2);
-
-            float rnx = cosYaw * nx - sinYaw * nz;
-            float rnz = sinYaw * nx + cosYaw * nz;
+            float rnx = nx;
+            float rnz = nz;
 
             float u = tBuf.get(idx * 2);
             float v = tBuf.get(idx * 2 + 1);

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/MobEntitiesRenderer.java
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/renderers/MobEntitiesRenderer.java
@@ -6,11 +6,8 @@ import fr.rhumun.game.worldcraftopengl.entities.MobEntity;
 import fr.rhumun.game.worldcraftopengl.entities.player.Player;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.GraphicModule;
 import fr.rhumun.game.worldcraftopengl.outputs.graphic.utils.ShaderManager;
-import org.lwjgl.opengl.GL30C;
-
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
-import java.util.Arrays;
 import java.util.Iterator;
 
 import static org.lwjgl.opengl.GL11.*;
@@ -29,28 +26,9 @@ public class MobEntitiesRenderer extends GlobalRenderer {
     }
 
     public void render() {
-        update();
-
         glBindVertexArray(this.getVAO());
         glBindBuffer(GL_ARRAY_BUFFER, this.getVBO());
-        fillBuffers();
-        glBufferData(GL_ARRAY_BUFFER, this.getVerticesBuffer(), GL_DYNAMIC_DRAW);
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this.getEBO());
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesBuffer(), GL_DYNAMIC_DRAW);
-//
-        glDrawElements(GL_TRIANGLES, this.getIndicesArray().length, GL_UNSIGNED_INT, 0);
-//
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-        glBindVertexArray(0);
-//
-        this.getIndices().clear();
-        this.getVertices().clear();
-    }
-
-    public void update() {
-        this.getVertices().clear();
-        this.getIndices().clear();
 
         Iterator<MobEntity> it = player.getLocation().getWorld().getEntities().stream()
                 .filter(e -> e instanceof MobEntity)
@@ -62,14 +40,28 @@ public class MobEntitiesRenderer extends GlobalRenderer {
             Model model = mob.getModel();
             if (model == null || mob.getAnimator() == null) continue;
 
+            this.getVertices().clear();
+            this.getIndices().clear();
+
+            raster(mob, model);
+            this.toArrays();
+            fillBuffers();
+
             ShaderManager.ANIMATED_ENTITY_SHADER.use();
             mob.getAnimator().sendToShader(ShaderManager.ANIMATED_ENTITY_SHADER);
 
-            raster(mob, model);
+            glBufferData(GL_ARRAY_BUFFER, this.getVerticesBuffer(), GL_DYNAMIC_DRAW);
+            glBufferData(GL_ELEMENT_ARRAY_BUFFER, this.getIndicesBuffer(), GL_DYNAMIC_DRAW);
+            glDrawElements(GL_TRIANGLES, this.getIndicesArray().length, GL_UNSIGNED_INT, 0);
         }
 
-        this.toArrays();
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+        glBindVertexArray(0);
+        this.getVertices().clear();
+        this.getIndices().clear();
     }
+
 
     private void raster(MobEntity entity, Model model) {
         Mesh obj = model.get();
@@ -79,7 +71,8 @@ public class MobEntitiesRenderer extends GlobalRenderer {
         FloatBuffer nBuf = obj.getNormalsBuffer().duplicate();
         FloatBuffer tBuf = obj.getTexCoordsBuffer().duplicate();
         IntBuffer iBuf = obj.getIndicesBuffer().duplicate();
-        IntBuffer boneBuf = obj.getBoneIDsBuffer().duplicate();
+        FloatBuffer boneBuf = obj.getBoneIDsBuffer().duplicate();
+        FloatBuffer weightBuf = obj.getBoneWeightsBuffer().duplicate();
 
         float yawRad = (float) Math.toRadians(entity.getLocation().getYaw());
         float cosYaw = (float) Math.cos(yawRad);
@@ -113,10 +106,26 @@ public class MobEntitiesRenderer extends GlobalRenderer {
             float u = tBuf.get(idx * 2);
             float v = tBuf.get(idx * 2 + 1);
 
-            int boneID = boneBuf.get(idx);
             int texture = entity.getTextureID();
 
-            float[] vertex = new float[]{vx, vy, vz, u, v, texture, rnx, ny, rnz, boneID};
+            float id0 = boneBuf.get(idx * 4);
+            float id1 = boneBuf.get(idx * 4 + 1);
+            float id2 = boneBuf.get(idx * 4 + 2);
+            float id3 = boneBuf.get(idx * 4 + 3);
+
+            float w0 = weightBuf.get(idx * 4);
+            float w1 = weightBuf.get(idx * 4 + 1);
+            float w2 = weightBuf.get(idx * 4 + 2);
+            float w3 = weightBuf.get(idx * 4 + 3);
+
+            float[] vertex = new float[]{
+                    vx, vy, vz,
+                    u, v,
+                    texture,
+                    rnx, ny, rnz,
+                    id0, id1, id2, id3,
+                    w0, w1, w2, w3
+            };
             this.addVertex(vertex);
         }
     }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/shaders/game/animated_entity_shader.glsl
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/shaders/game/animated_entity_shader.glsl
@@ -5,7 +5,8 @@ layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec2 inTexCoord;
 layout(location = 2) in float inTextureIndex;
 layout(location = 3) in vec3 inNormal;
-layout(location = 4) in int inBoneID;
+layout(location = 4) in vec4 inBoneIDs;
+layout(location = 5) in vec4 inWeights;
 
 uniform mat4 projection;
 uniform mat4 view;
@@ -16,12 +17,15 @@ out float fragTextureIndex;
 out vec3 fragNormal;
 
 void main() {
-    mat4 boneTransform = boneMatrices[inBoneID];
-    vec4 worldPos = boneTransform * vec4(inPosition, 1.0);
+    mat4 skinMatrix = 
+        inWeights.x * boneMatrices[int(inBoneIDs.x)] +
+        inWeights.y * boneMatrices[int(inBoneIDs.y)] +
+        inWeights.z * boneMatrices[int(inBoneIDs.z)] +
+        inWeights.w * boneMatrices[int(inBoneIDs.w)];
+    vec4 worldPos = skinMatrix * vec4(inPosition, 1.0);
     fragTexCoord = inTexCoord;
     fragTextureIndex = inTextureIndex;
-    fragNormal = mat3(transpose(inverse(boneTransform))) * inNormal;
-    vec4 skinnedPos = boneMatrices[inBoneID] * vec4(inPosition, 1.0);
-    skinnedPos.xyz *= 0.05; // Réduit l’échelle
-    gl_Position = projection * view * worldPos * skinnedPos;
+    fragNormal = mat3(transpose(inverse(skinMatrix))) * inNormal;
+    worldPos.xyz *= 0.05;
+    gl_Position = projection * view * worldPos;
 }

--- a/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/shaders/game/animated_entity_shader.glsl
+++ b/src/main/java/fr/rhumun/game/worldcraftopengl/outputs/graphic/shaders/game/animated_entity_shader.glsl
@@ -10,6 +10,7 @@ layout(location = 5) in vec4 inWeights;
 
 uniform mat4 projection;
 uniform mat4 view;
+uniform mat4 model;
 uniform mat4 boneMatrices[64];
 
 out vec2 fragTexCoord;
@@ -17,15 +18,14 @@ out float fragTextureIndex;
 out vec3 fragNormal;
 
 void main() {
-    mat4 skinMatrix = 
+    mat4 skinMatrix =
         inWeights.x * boneMatrices[int(inBoneIDs.x)] +
         inWeights.y * boneMatrices[int(inBoneIDs.y)] +
         inWeights.z * boneMatrices[int(inBoneIDs.z)] +
         inWeights.w * boneMatrices[int(inBoneIDs.w)];
-    vec4 worldPos = skinMatrix * vec4(inPosition, 1.0);
+    vec4 worldPos = model * skinMatrix * vec4(inPosition, 1.0);
     fragTexCoord = inTexCoord;
     fragTextureIndex = inTextureIndex;
-    fragNormal = mat3(transpose(inverse(skinMatrix))) * inNormal;
-    worldPos.xyz *= 0.05;
+    fragNormal = mat3(transpose(inverse(model * skinMatrix))) * inNormal;
     gl_Position = projection * view * worldPos;
 }


### PR DESCRIPTION
## Summary
- parse bone weights and IDs in `Mesh.loadSkinnedMesh`
- store bone offset matrices and hierarchy with `GltfAnimationLoader`
- compute final bone matrices in `Animator`
- expose bind matrices in `Bone`
- adjust GL attribute layout for skinning
- render animated entities with bone matrices
- update GLSL vertex shader for GPU skinning
- **fix animated entity renderer to update bone uniforms per entity**

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685c9a5ba81c833085973f3cc42805dd